### PR TITLE
feat: add Account Context

### DIFF
--- a/frontend/src/apis/authServices.js
+++ b/frontend/src/apis/authServices.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-// import MockAdapter from 'axios-mock-adapter';
+import MockAdapter from 'axios-mock-adapter';
 import { TEST_CONFIG } from '../config';
 
 const API = axios.create({
@@ -9,20 +9,21 @@ const API = axios.create({
   },
 });
 
-// MockAdapter를 사용하여 가짜 응답 생성 - npm install axios-mock-adapter 필요!!
-// const mock = new MockAdapter(API);
+// MockAdapter를 사용하여 가짜 응답 생성
+// npm install axios-mock-adapter 필요!!
+const mock = new MockAdapter(API);
 
 // authToken 테스트용 응답
-// mock.onGet('/auth/authenticate').reply(config => {
-//   const authToken = config.headers.Authorization;
-//   if (authToken === 'Bearer fake-access-token') {
-//     return [200, { isValid: true }];
-//   } else {
-//     return [401, { isValid: false }];
-//   }
-// });
+mock.onGet('/auth/authenticate').reply(config => {
+  const authToken = config.headers.Authorization;
+  if (authToken === 'Bearer fake-access-token') {
+    return [200, { isValid: true }];
+  } else {
+    return [401, { isValid: false }];
+  }
+});
 
-// // logIn 테스트용 응답
+// // logIn 테스트용 응답 - 시간 지연 없음
 // mock.onPost('/user/login').reply(config => {
 //   const { email, password } = JSON.parse(config.data);
 //   if (email === 'example@example.com' && password === 'password123') {
@@ -38,38 +39,80 @@ const API = axios.create({
 //   }
 // });
 
-// mock.onPost('/auth/refresh').reply(config => {
-//   const header = config.headers.Authorization;
-//   const body = JSON.parse(config.data);
+// logIn 테스트용 응답 - 시간 지연
+mock.onPost('/user/login').reply(config => {
+  const { email, password } = JSON.parse(config.data);
 
-//   if (body.refreshToken === 'fake-refresh-token') {
-//     return [200, { accessToken: 'fake-access-token' }];
-//   }
-//   return [401, { message: 'Invalid refresh token' }];
-// });
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (email === 'example@example.com' && password === 'password123') {
+        resolve([
+          201,
+          {
+            accessToken: 'fake-access-token',
+            refreshToken: 'fake-refresh-token',
+          },
+        ]);
+      } else {
+        reject([
+          401,
+          {
+            message: 'Invalid email or password',
+          },
+        ]);
+      }
+    }, 1000);
+  });
+});
 
-// // logOut 테스트용 응답
-// mock.onGet('/user/logout').reply(200, {
-//   message: 'Logged out',
-// });
+mock.onPost('/auth/refresh').reply(config => {
+  const body = JSON.parse(config.data);
+
+  return new Promise((resolve, reject) => {
+    if (body.refreshToken === 'fake-refresh-token') {
+      resolve([200, { accessToken: 'fake-access-token' }]);
+    }
+    const error = new Error('Invalid refresh token');
+    error.status = 401;
+    reject(error);
+  });
+});
+
+// logOut 테스트용 응답
+mock.onGet('/user/logout').reply(200, {
+  message: 'Logged out',
+});
+
+// logOut 테스트용 응답 - 시간 지연
+mock.onGet('/user/logout').reply(config => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve([
+        200,
+        {
+          message: 'Logged out',
+        },
+      ]);
+      reject([
+        401,
+        {
+          message: 'Failed to log out',
+        },
+      ]);
+    }, 2000);
+  });
+});
 
 const logInUser = async (email, password) => {
   return API.post('/user/login', { email: email, password: password });
 };
 
-// login 시간 지연 테스트용 코드
-// const logInUser = async (email, password) => {
-//   return new Promise((resolve, reject) => {
-//     setTimeout(() => {
-//       resolve({
-//         data: {
-//           accessToken: 'fake-access-token',
-//           refreshToken: 'fake-refresh-token',
-//         },
-//       });
-//     }, 1000);
-//   });
-// };
+const testAPI = async (email, password) => {
+  return axios.post('http://3.36.88.196:3000/users', {
+    username: 'leejaewon babo',
+    password: 'iloveyou',
+  });
+};
 
 const logOutUser = async accessToken => {
   return API.get('/user/logout', {
@@ -114,6 +157,7 @@ const refreshAccessToken = async (accessToken, refreshToken) => {
 };
 
 export const authServices = {
+  testAPI,
   signUpUser,
   logInUser,
   logOutUser,

--- a/frontend/src/apis/authServices.js
+++ b/frontend/src/apis/authServices.js
@@ -1,0 +1,124 @@
+import axios from 'axios';
+// import MockAdapter from 'axios-mock-adapter';
+import { TEST_CONFIG } from '../config';
+
+const API = axios.create({
+  baseURL: TEST_CONFIG.BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// MockAdapter를 사용하여 가짜 응답 생성 - npm install axios-mock-adapter 필요!!
+// const mock = new MockAdapter(API);
+
+// authToken 테스트용 응답
+// mock.onGet('/auth/authenticate').reply(config => {
+//   const authToken = config.headers.Authorization;
+//   if (authToken === 'Bearer fake-access-token') {
+//     return [200, { isValid: true }];
+//   } else {
+//     return [401, { isValid: false }];
+//   }
+// });
+
+// // logIn 테스트용 응답
+// mock.onPost('/user/login').reply(config => {
+//   const { email, password } = JSON.parse(config.data);
+//   if (email === 'example@example.com' && password === 'password123') {
+//     return [
+//       201,
+//       {
+//         accessToken: 'fake-access-token',
+//         refreshToken: 'fake-refresh-token',
+//       },
+//     ];
+//   } else {
+//     return [401, { message: 'Invalid email or password' }];
+//   }
+// });
+
+// mock.onPost('/auth/refresh').reply(config => {
+//   const header = config.headers.Authorization;
+//   const body = JSON.parse(config.data);
+
+//   if (body.refreshToken === 'fake-refresh-token') {
+//     return [200, { accessToken: 'fake-access-token' }];
+//   }
+//   return [401, { message: 'Invalid refresh token' }];
+// });
+
+// // logOut 테스트용 응답
+// mock.onGet('/user/logout').reply(200, {
+//   message: 'Logged out',
+// });
+
+const logInUser = async (email, password) => {
+  return API.post('/user/login', { email: email, password: password });
+};
+
+// login 시간 지연 테스트용 코드
+// const logInUser = async (email, password) => {
+//   return new Promise((resolve, reject) => {
+//     setTimeout(() => {
+//       resolve({
+//         data: {
+//           accessToken: 'fake-access-token',
+//           refreshToken: 'fake-refresh-token',
+//         },
+//       });
+//     }, 1000);
+//   });
+// };
+
+const logOutUser = async accessToken => {
+  return API.get('/user/logout', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+const signUpUser = async (email, password, name) => {
+  return API.post('/user/signUp', {
+    email: email,
+    password: password,
+    name: name,
+  });
+};
+
+const checkEmailAvailability = async email => {
+  return API.get('/email/check', { params: { email } });
+};
+
+const verifyAuthCode = async authNum => {
+  return API.post('/auth', { authNum });
+};
+
+const verifyAccessToken = async accessToken => {
+  return API.get('/auth/authenticate', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};
+
+const refreshAccessToken = async (accessToken, refreshToken) => {
+  return API.post(
+    '/auth/refresh',
+    { refreshToken: refreshToken },
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
+};
+
+export const authServices = {
+  signUpUser,
+  logInUser,
+  logOutUser,
+  checkEmailAvailability,
+  verifyAuthCode,
+  verifyAccessToken,
+  refreshAccessToken,
+};

--- a/frontend/src/apis/authServices.js
+++ b/frontend/src/apis/authServices.js
@@ -103,18 +103,18 @@ mock.onGet('/user/logout').reply(config => {
   });
 });
 
-const logInUser = async (email, password) => {
+const logInUser = async ({ email, password }) => {
   return API.post('/user/login', { email: email, password: password });
 };
 
-const testAPI = async (email, password) => {
+const testAPI = async ({ email, password }) => {
   return axios.post('http://3.36.88.196:3000/users', {
     username: 'leejaewon babo',
     password: 'iloveyou',
   });
 };
 
-const logOutUser = async accessToken => {
+const logOutUser = async ({ accessToken }) => {
   return API.get('/user/logout', {
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -122,7 +122,7 @@ const logOutUser = async accessToken => {
   });
 };
 
-const signUpUser = async (email, password, name) => {
+const signUpUser = async ({ email, password, name }) => {
   return API.post('/user/signUp', {
     email: email,
     password: password,
@@ -130,15 +130,15 @@ const signUpUser = async (email, password, name) => {
   });
 };
 
-const checkEmailAvailability = async email => {
+const checkEmailAvailability = async ({ email }) => {
   return API.get('/email/check', { params: { email } });
 };
 
-const verifyAuthCode = async authNum => {
-  return API.post('/auth', { authNum });
+const verifyAuthCode = async ({ authNum }) => {
+  return API.post('/auth', { authNum: authNum });
 };
 
-const verifyAccessToken = async accessToken => {
+const verifyAccessToken = async ({ accessToken }) => {
   return API.get('/auth/authenticate', {
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -146,7 +146,7 @@ const verifyAccessToken = async accessToken => {
   });
 };
 
-const refreshAccessToken = async (accessToken, refreshToken) => {
+const refreshAccessToken = async ({ accessToken, refreshToken }) => {
   return API.post(
     '/auth/refresh',
     { refreshToken: refreshToken },

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,5 @@
+export const TEST_CONFIG = {
+  BASE_URL: process.env.REACT_APP_BASE_URL,
+  TEST_EMAIL: process.env.REACT_APP_TEST_EMAIL,
+  TEST_PASSWORD: process.env.REACT_APP_TEST_PASSWORD,
+};

--- a/frontend/src/contexts/AccountContexts.js
+++ b/frontend/src/contexts/AccountContexts.js
@@ -5,17 +5,18 @@ const AccountContext = createContext();
 
 const AccountContextProvider = ({ children }) => {
   const [accessToken, setAccessToken] = useState(null);
-  const { logOutUser } = authServices;
 
-  const handleLogOut = async () => {
+  const logOut = async () => {
     try {
-      const response = await logOutUser();
+      const response = await authServices.logOutUser();
       if (response.status === 200) {
         setAccessToken(null);
         localStorage.removeItem('refreshToken');
+        return true;
       }
     } catch (error) {
       console.error('Logout failed', error);
+      return false;
     }
   };
 
@@ -24,7 +25,7 @@ const AccountContextProvider = ({ children }) => {
       value={{
         setAccessToken,
         accessToken,
-        handleLogOut,
+        logOut,
       }}
     >
       {children}

--- a/frontend/src/contexts/AccountContexts.js
+++ b/frontend/src/contexts/AccountContexts.js
@@ -8,7 +8,9 @@ const AccountContextProvider = ({ children }) => {
 
   const logOut = async () => {
     try {
-      const response = await authServices.logOutUser();
+      const response = await authServices.logOutUser({
+        accessToken: accessToken,
+      });
       if (response.status === 200) {
         setAccessToken(null);
         localStorage.removeItem('refreshToken');

--- a/frontend/src/contexts/AccountContexts.js
+++ b/frontend/src/contexts/AccountContexts.js
@@ -1,0 +1,35 @@
+import React, { createContext, useState } from 'react';
+import { authServices } from '../apis/authServices';
+
+const AccountContext = createContext();
+
+const AccountContextProvider = ({ children }) => {
+  const [accessToken, setAccessToken] = useState(null);
+  const { logOutUser } = authServices;
+
+  const handleLogOut = async () => {
+    try {
+      const response = await logOutUser();
+      if (response.status === 200) {
+        setAccessToken(null);
+        localStorage.removeItem('refreshToken');
+      }
+    } catch (error) {
+      console.error('Logout failed', error);
+    }
+  };
+
+  return (
+    <AccountContext.Provider
+      value={{
+        setAccessToken,
+        accessToken,
+        handleLogOut,
+      }}
+    >
+      {children}
+    </AccountContext.Provider>
+  );
+};
+
+export { AccountContext, AccountContextProvider };

--- a/frontend/src/contexts/index.js
+++ b/frontend/src/contexts/index.js
@@ -1,0 +1,3 @@
+import { AccountContext, AccountContextProvider } from './AccountContexts';
+
+export { AccountContext, AccountContextProvider };

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -20,7 +20,10 @@ const useAuth = () => {
 
   const logInUser = async (email, password) => {
     try {
-      const response = await authServices.logInUser(email, password);
+      const response = await authServices.logInUser({
+        email: email,
+        password: password,
+      });
       return {
         success: true,
         data: response.data,
@@ -38,10 +41,10 @@ const useAuth = () => {
       if (!refreshToken) {
         return false;
       }
-      const response = await authServices.refreshAccessToken(
-        accessToken,
-        refreshToken,
-      );
+      const response = await authServices.refreshAccessToken({
+        accseeToken: accessToken,
+        refreshToken: refreshToken,
+      });
       if (response.status === 200) {
         setAccessToken(response.data.accessToken);
         return true;

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -18,28 +18,29 @@ const useAuth = () => {
     }
   };
 
-  const handleLogIn = async (email, password) => {
+  const logInUser = async (email, password) => {
     try {
       const response = await authServices.logInUser(email, password);
-      setAccessToken(response.data.accessToken);
-      localStorage.setItem('refreshToken', response.data.refreshToken);
-      navigate('/main');
+      return {
+        success: true,
+        data: response.data,
+      };
     } catch (error) {
-      console.error('Login failed:', error);
-    } finally {
-      return;
+      return {
+        success: false,
+        message: error.response?.data?.message || '로그인에 실패했습니다.',
+      };
     }
   };
 
   const refreshAuthorization = async () => {
     try {
-      const storedRefreshToken = localStorage.getItem('refreshToken');
-      if (!storedRefreshToken) {
+      if (!refreshToken) {
         return false;
       }
       const response = await authServices.refreshAccessToken(
         accessToken,
-        storedRefreshToken,
+        refreshToken,
       );
       if (response.status === 200) {
         setAccessToken(response.data.accessToken);
@@ -50,20 +51,16 @@ const useAuth = () => {
       }
     } catch (error) {
       console.error('Failed to refresh access token', error);
+      return false;
     }
   };
 
   const handleCheckAuth = async () => {
     try {
-      if (!refreshToken) {
-        alert('다시 로그인 해주세요');
-        navigate('/auth');
-        return;
-      }
       if (accessToken === null) {
         const isRefreshed = await refreshAuthorization();
         if (!isRefreshed) {
-          alert('다시 로그인 해주세요');
+          alert('로그인이 필요합니다.');
           navigate('/auth');
         }
         return isRefreshed;
@@ -77,7 +74,7 @@ const useAuth = () => {
 
   return {
     verifyToken,
-    handleLogIn,
+    logInUser,
     refreshAuthorization,
     handleCheckAuth,
   };

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,86 @@
+import { useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AccountContext } from '../contexts/AccountContexts';
+import { authServices } from '../apis/authServices';
+
+const useAuth = () => {
+  const navigate = useNavigate();
+  const { accessToken, setAccessToken } = useContext(AccountContext);
+  const refreshToken = localStorage.getItem('refreshToken');
+
+  const verifyToken = async () => {
+    try {
+      const response = await authServices.authToken(accessToken);
+      return response;
+    } catch (error) {
+      console.error('Token verification failed', error);
+      throw error;
+    }
+  };
+
+  const handleLogIn = async (email, password) => {
+    try {
+      const response = await authServices.logInUser(email, password);
+      setAccessToken(response.data.accessToken);
+      localStorage.setItem('refreshToken', response.data.refreshToken);
+      navigate('/main');
+    } catch (error) {
+      console.error('Login failed:', error);
+    } finally {
+      return;
+    }
+  };
+
+  const refreshAuthorization = async () => {
+    try {
+      const storedRefreshToken = localStorage.getItem('refreshToken');
+      if (!storedRefreshToken) {
+        return false;
+      }
+      const response = await authServices.refreshAccessToken(
+        accessToken,
+        storedRefreshToken,
+      );
+      if (response.status === 200) {
+        setAccessToken(response.data.accessToken);
+        return true;
+      } else {
+        console.error('Failed to refresh access token', response.status);
+        return false;
+      }
+    } catch (error) {
+      console.error('Failed to refresh access token', error);
+    }
+  };
+
+  const handleCheckAuth = async () => {
+    try {
+      if (!refreshToken) {
+        alert('다시 로그인 해주세요');
+        navigate('/auth');
+        return;
+      }
+      if (accessToken === null) {
+        const isRefreshed = await refreshAuthorization();
+        if (!isRefreshed) {
+          alert('다시 로그인 해주세요');
+          navigate('/auth');
+        }
+        return isRefreshed;
+      }
+      return true;
+    } catch (error) {
+      console.error('Failed to check auth', error);
+      return false;
+    }
+  };
+
+  return {
+    verifyToken,
+    handleLogIn,
+    refreshAuthorization,
+    handleCheckAuth,
+  };
+};
+
+export default useAuth;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import Router from './Router';
 
+import { AccountContextProvider } from './contexts';
+
 import GlobalStyle from './styles/GlobalStyle';
 import theme from './styles/theme';
 import { ThemeProvider } from 'styled-components';
@@ -14,7 +16,9 @@ root.render(
   <>
     <GlobalStyle />
     <ThemeProvider theme={theme}>
-      <Router />
+      <AccountContextProvider>
+        <Router />
+      </AccountContextProvider>
     </ThemeProvider>
   </>,
 );

--- a/frontend/src/pages/Auth/Auth.js
+++ b/frontend/src/pages/Auth/Auth.js
@@ -1,7 +1,33 @@
-import React from 'react';
+import React, { useState } from 'react';
+import useAuth from '../../hooks/useAuth';
+import { TEST_CONFIG } from '../../config';
+import useFetch from '../../hooks/useFetch';
 
 const Auth = () => {
-  return <div>Auth</div>;
+  const { fetchData } = useFetch();
+  const [isLoading, setIsLoading] = useState(false);
+  const { handleLogIn } = useAuth();
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <>
+      <div>Auth</div>
+      <button
+        onClick={async () => {
+          setIsLoading(true);
+          const result = await fetchData(() =>
+            handleLogIn(TEST_CONFIG.TEST_EMAIL, TEST_CONFIG.TEST_PASSWORD),
+          );
+          setIsLoading(result.isLoading);
+        }}
+      >
+        login
+      </button>
+    </>
+  );
 };
 
 export default Auth;

--- a/frontend/src/pages/Auth/Auth.js
+++ b/frontend/src/pages/Auth/Auth.js
@@ -1,34 +1,41 @@
 import React, { useState, useContext } from 'react';
 import useAuth from '../../hooks/useAuth';
+import useFetch from '../../hooks/useFetch';
 import { TEST_CONFIG } from '../../config';
 import { AccountContext } from '../../contexts/AccountContexts';
 import { useNavigate } from 'react-router-dom';
 
 const Auth = () => {
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoginLoading, setIsLoginLoading] = useState(false);
   const { setAccessToken } = useContext(AccountContext);
   const { logInUser } = useAuth();
+  const { fetchData } = useFetch();
   const navigate = useNavigate();
 
   const handleLogin = async () => {
-    setIsLoading(true);
-    const result = await logInUser(
-      TEST_CONFIG.TEST_EMAIL,
-      TEST_CONFIG.TEST_PASSWORD,
+    setIsLoginLoading(true);
+    const response = await fetchData(() =>
+      logInUser(TEST_CONFIG.TEST_EMAIL, TEST_CONFIG.TEST_PASSWORD),
     );
-    setIsLoading(false);
-    if (result.success) {
-      setAccessToken(result.data.accessToken);
-      localStorage.setItem('refreshToken', result.data.refreshToken);
+    const {
+      isLoading: isLoginLoading,
+      data: loginData,
+      error: loginError,
+    } = response;
+    if (!isLoginLoading) {
+      setIsLoginLoading(false);
+      setAccessToken(loginData.accessToken);
+      localStorage.setItem('refreshToken', loginData.refreshToken);
       alert('로그인 되었습니다.');
       navigate('/main');
-    } else {
-      alert(result.message);
+    } else if (loginError) {
+      setIsLoginLoading(false);
+      alert(loginError);
       return;
     }
   };
 
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoginLoading) return <div>Loading...</div>;
 
   return (
     <>

--- a/frontend/src/pages/Auth/Auth.js
+++ b/frontend/src/pages/Auth/Auth.js
@@ -1,31 +1,39 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import useAuth from '../../hooks/useAuth';
 import { TEST_CONFIG } from '../../config';
-import useFetch from '../../hooks/useFetch';
+import { AccountContext } from '../../contexts/AccountContexts';
+import { useNavigate } from 'react-router-dom';
 
 const Auth = () => {
-  const { fetchData } = useFetch();
   const [isLoading, setIsLoading] = useState(false);
-  const { handleLogIn } = useAuth();
+  const { setAccessToken } = useContext(AccountContext);
+  const { logInUser } = useAuth();
+  const navigate = useNavigate();
 
-  if (isLoading) {
-    return <div>Loading...</div>;
-  }
+  const handleLogin = async () => {
+    setIsLoading(true);
+    const result = await logInUser(
+      TEST_CONFIG.TEST_EMAIL,
+      TEST_CONFIG.TEST_PASSWORD,
+    );
+    setIsLoading(false);
+    if (result.success) {
+      setAccessToken(result.data.accessToken);
+      localStorage.setItem('refreshToken', result.data.refreshToken);
+      alert('로그인 되었습니다.');
+      navigate('/main');
+    } else {
+      alert(result.message);
+      return;
+    }
+  };
+
+  if (isLoading) return <div>Loading...</div>;
 
   return (
     <>
       <div>Auth</div>
-      <button
-        onClick={async () => {
-          setIsLoading(true);
-          const result = await fetchData(() =>
-            handleLogIn(TEST_CONFIG.TEST_EMAIL, TEST_CONFIG.TEST_PASSWORD),
-          );
-          setIsLoading(result.isLoading);
-        }}
-      >
-        login
-      </button>
+      <button onClick={handleLogin}>로그인</button>
     </>
   );
 };

--- a/frontend/src/pages/InGame/components/Thumbnail.js
+++ b/frontend/src/pages/InGame/components/Thumbnail.js
@@ -39,7 +39,6 @@ const UserInfo = ({ userId }) => {
 };
 
 const UserStatus = ({ isActive }) => {
-  console.log(isActive);
   return <StatusIcon isActive={isActive} />;
 };
 

--- a/frontend/src/pages/Main/Main.js
+++ b/frontend/src/pages/Main/Main.js
@@ -2,20 +2,20 @@ import React, { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import useAuth from '../../hooks/useAuth';
-import { AccountContext } from '../../contexts/AccountContexts';
 
 const Main = () => {
   const { handleCheckAuth } = useAuth();
-  const { accessToken } = useContext(AccountContext);
   const navigate = useNavigate();
   // challenge id는 서버에서 받아온 값으로 대체
   const challengeId = '1234';
+
+  const refreshToken = localStorage.getItem('refreshToken');
 
   useEffect(() => {
     handleCheckAuth();
   });
 
-  if (!accessToken) {
+  if (!refreshToken) {
     return <div>Unauthorized</div>;
   }
 

--- a/frontend/src/pages/Main/Main.js
+++ b/frontend/src/pages/Main/Main.js
@@ -1,23 +1,43 @@
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import useAuth from '../../hooks/useAuth';
+import { AccountContext } from '../../contexts/AccountContexts';
 
 const Main = () => {
+  const { handleCheckAuth } = useAuth();
+  const { accessToken } = useContext(AccountContext);
   const navigate = useNavigate();
-
   // challenge id는 서버에서 받아온 값으로 대체
   const challengeId = '1234';
 
+  useEffect(() => {
+    handleCheckAuth();
+  });
+
+  if (!accessToken) {
+    return <div>Unauthorized</div>;
+  }
+
   return (
     <Wrapper>
-      <p>Main</p>
-      <EnterBtn
-        onClick={() => {
-          navigate(`/inGame/${challengeId}`);
-        }}
-      >
-        Start Game
-      </EnterBtn>
+      <div>
+        <p>Main</p>
+        <button
+          onClick={() => {
+            navigate('/settings');
+          }}
+        >
+          settings
+        </button>
+        <EnterBtn
+          onClick={() => {
+            navigate(`/inGame/${challengeId}`);
+          }}
+        >
+          Start Game
+        </EnterBtn>
+      </div>
     </Wrapper>
   );
 };

--- a/frontend/src/pages/Main/Main.js
+++ b/frontend/src/pages/Main/Main.js
@@ -1,23 +1,33 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import useAuth from '../../hooks/useAuth';
 
 const Main = () => {
+  const [isAuthorized, setIsAuthorized] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
   const { handleCheckAuth } = useAuth();
   const navigate = useNavigate();
+
   // challenge id는 서버에서 받아온 값으로 대체
   const challengeId = '1234';
 
-  const refreshToken = localStorage.getItem('refreshToken');
-
   useEffect(() => {
-    handleCheckAuth();
-  });
+    const fetchData = async () => {
+      const result = await handleCheckAuth();
+      if (!result || result.error) {
+        setIsAuthorized(false);
+        navigate('/auth');
+      } else {
+        setIsAuthorized(true);
+      }
+    };
+    fetchData();
+  }, []);
 
-  if (!refreshToken) {
-    return <div>Unauthorized</div>;
-  }
+  if (isLoading) return <div>Loading...</div>;
+  if (isAuthorized === null)
+    return <div>접근이 허용되지 않은 페이지입니다.</div>;
 
   return (
     <Wrapper>

--- a/frontend/src/pages/Settings/Settings.js
+++ b/frontend/src/pages/Settings/Settings.js
@@ -1,7 +1,38 @@
-import React from 'react';
-
+import React, { useContext, useEffect } from 'react';
+import { AccountContext } from '../../contexts/AccountContexts';
+import { useNavigate } from 'react-router-dom';
+import useAuth from '../../hooks/useAuth';
 const Settings = () => {
-  return <div>Settings</div>;
+  const { handleLogOut } = useContext(AccountContext);
+  const { handleCheckAuth } = useAuth();
+  const navigate = useNavigate();
+
+  const refreshToken = localStorage.getItem('refreshToken');
+  let contents = null;
+
+  useEffect(() => {
+    handleCheckAuth();
+  }, [handleCheckAuth]);
+
+  if (refreshToken === null) {
+    contents = <div>Loading...</div>;
+  } else {
+    contents = (
+      <>
+        <button
+          onClick={() => {
+            handleLogOut();
+            alert('로그아웃 되었습니다.');
+            navigate('/auth');
+          }}
+        >
+          Log Out
+        </button>
+        <div>Settings</div>
+      </>
+    );
+  }
+  return <>{contents}</>;
 };
 
 export default Settings;

--- a/frontend/src/pages/Settings/Settings.js
+++ b/frontend/src/pages/Settings/Settings.js
@@ -14,7 +14,7 @@ const Settings = () => {
     handleCheckAuth();
   }, [handleCheckAuth]);
 
-  if (refreshToken === null) {
+  if (!refreshToken) {
     contents = <div>Loading...</div>;
   } else {
     contents = (

--- a/frontend/src/pages/Settings/Settings.js
+++ b/frontend/src/pages/Settings/Settings.js
@@ -2,40 +2,69 @@ import React, { useContext, useEffect, useState } from 'react';
 import { AccountContext } from '../../contexts/AccountContexts';
 import { useNavigate } from 'react-router-dom';
 import useAuth from '../../hooks/useAuth';
+import useFetch from '../../hooks/useFetch';
 
 const Settings = () => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [isAuthorized, setIsAuthorized] = useState(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+  const [isAuthorized, setIsAuthorized] = useState(false);
+  const [isLogoutLoading, setIsLogoutLoading] = useState(false);
   const { logOut } = useContext(AccountContext);
+  const { fetchData } = useFetch();
   const { handleCheckAuth } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
-    const fetchData = async () => {
-      const result = await handleCheckAuth();
-      if (!result || result.error) {
-        setIsAuthorized(false);
-        navigate('/auth');
-      } else {
-        setIsAuthorized(true);
-      }
-    };
-    fetchData();
+    checkAuthorize();
   }, []);
 
-  const handleLogOut = async () => {
-    setIsLoading(true);
-    const result = await logOut();
-    if (result) {
-      alert('로그아웃 되었습니다.');
-      navigate('/auth');
+  const checkAuthorize = async () => {
+    try {
+      const response = await fetchData(() => handleCheckAuth());
+      const {
+        isLoading: isAuthLoading,
+        data: authData,
+        error: authError,
+      } = response;
+      if (!isAuthLoading) {
+        setIsAuthLoading(false);
+        setIsAuthorized(true);
+      } else if (authError) {
+        setIsAuthLoading(false);
+        setIsAuthorized(false);
+        navigate('/auth');
+      }
+    } catch (error) {
+      console.error(error);
+      alert(error);
     }
-    setIsLoading(false);
   };
 
-  if (isLoading) return <div>Loading...</div>;
-  if (isAuthorized === null)
+  const handleLogOut = async () => {
+    try {
+      setIsLogoutLoading(true);
+      const response = await fetchData(() => logOut());
+      const {
+        isLoading: isLogoutLoading,
+        data: logoutData,
+        error: logoutError,
+      } = response;
+      if (!isLogoutLoading) {
+        alert('로그아웃 되었습니다.');
+        navigate('/auth');
+        setIsLogoutLoading(false);
+      } else if (logoutError) {
+        alert(logoutError);
+        setIsLogoutLoading(false);
+      }
+    } catch (error) {
+      console.error(error);
+      alert(error);
+    }
+  };
+
+  if (isAuthorized === false)
     return <div>접근이 허용되지 않은 페이지입니다.</div>;
+  if (isLogoutLoading || isAuthLoading) return <div>Loading...</div>;
 
   return (
     <>

--- a/frontend/src/pages/Settings/Settings.js
+++ b/frontend/src/pages/Settings/Settings.js
@@ -1,38 +1,48 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { AccountContext } from '../../contexts/AccountContexts';
 import { useNavigate } from 'react-router-dom';
 import useAuth from '../../hooks/useAuth';
+
 const Settings = () => {
-  const { handleLogOut } = useContext(AccountContext);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isAuthorized, setIsAuthorized] = useState(null);
+  const { logOut } = useContext(AccountContext);
   const { handleCheckAuth } = useAuth();
   const navigate = useNavigate();
 
-  const refreshToken = localStorage.getItem('refreshToken');
-  let contents = null;
-
   useEffect(() => {
-    handleCheckAuth();
-  }, [handleCheckAuth]);
+    const fetchData = async () => {
+      const result = await handleCheckAuth();
+      if (!result || result.error) {
+        setIsAuthorized(false);
+        navigate('/auth');
+      } else {
+        setIsAuthorized(true);
+      }
+    };
+    fetchData();
+  }, []);
 
-  if (!refreshToken) {
-    contents = <div>Loading...</div>;
-  } else {
-    contents = (
-      <>
-        <button
-          onClick={() => {
-            handleLogOut();
-            alert('로그아웃 되었습니다.');
-            navigate('/auth');
-          }}
-        >
-          Log Out
-        </button>
-        <div>Settings</div>
-      </>
-    );
-  }
-  return <>{contents}</>;
+  const handleLogOut = async () => {
+    setIsLoading(true);
+    const result = await logOut();
+    if (result) {
+      alert('로그아웃 되었습니다.');
+      navigate('/auth');
+    }
+    setIsLoading(false);
+  };
+
+  if (isLoading) return <div>Loading...</div>;
+  if (isAuthorized === null)
+    return <div>접근이 허용되지 않은 페이지입니다.</div>;
+
+  return (
+    <>
+      <button onClick={handleLogOut}>Log Out</button>
+      <div>Settings</div>
+    </>
+  );
 };
 
 export default Settings;


### PR DESCRIPTION
## #️⃣ Part

- [X] FE
- [ ] BE

## 📝 작업 내용
### `AccountContext.js`
logOut을 위한 핸들러와, 로그인 시에 받아오는 access token을 context로 관리할 수 있게 하였습니다.

### `useAuth.js`
인증에 자주 사용되는 로직을 위해 훅을 만들었습니다.
- `verifyToken()`
accessToken이 유효한지 검사하는 기능을 수행합니다.
- `handleLogIn()`
log in 버튼을 눌렀을 때, 로그인을 처리하는 기능을 구현했습니다. 
- `refreshAuthorization()`
access token은 없지만 refresh token이 존재 할 때(page refresh 등에 의해) refresh token을 이용하여 access token을 재발급 받을 수 있도록 했습니댜.
- `handleCheckAuth()`로 각 페이지마다 access token과 refresh token을 검사하여 사용자의 토큰 소유 여부에 따라 페이지에 접근할 수 있는지를 검사할 수 있도록 하였습니다.

### `authServices.js`
인증과 관련된 API호출을 위한 함수들을 구현했습니다. 
- `handleLogOut()` 
각 페이지에서 access token이 있는지 검사하고, 없으면 refresh token을 가져오는 을 구현하였습니다.

### 그 밖의 작업들
- `config.js` 
테스트를 위한 Base URL, TEST_EMAIL, TEST_PASSWORD를 추가했습니다.
- `src/contexts/index.js`
context import를 용이하게 하기위한 인덱스를 추가했습니다.
- `Main.js`, `Auth.js`
로직 테스트를 위한 버튼들과 함수들을 추가하였습니다.
