### PR TITLE
Feat: separate pose & face estimator from mission UI

### DIFF
--- a/frontend/src/pages/InGame/InGame.js
+++ b/frontend/src/pages/InGame/InGame.js
@@ -49,20 +49,21 @@ const InGame = () => {
     getConnectionToken,
     videoSession,
     startSession,
+    myVideoRef,
     myStream,
     setMyStream,
   } = useContext(GameContext);
 
   const [mateList, setMateList] = useState([]);
 
-  // const stopCamera = () => {
-  //   if (myStream) {
-  //     myStream.getTracks().forEach(track => {
-  //       track.stop();
-  //     });
-  //     setMyStream(null);
-  //   }
-  // };
+  const stopCamera = () => {
+    if (myStream) {
+      myStream.getTracks().forEach(track => {
+        track.stop();
+      });
+      setMyStream(null);
+    }
+  };
 
   useEffect(() => {
     if (challengeId) {
@@ -101,6 +102,8 @@ const InGame = () => {
       <InGameNav />
       <Wrapper>
         <MyVideo />
+        {GAME_MODE_COMPONENTS[inGameMode]}
+
         {/* {mateList.length > 0 && (
             <MatesVideoWrapper $isSingle={mateList.length === 1}>
               {mateList.map(({ userId }) => (
@@ -108,7 +111,7 @@ const InGame = () => {
               ))}
             </MatesVideoWrapper>
           )} */}
-        {/* <CloseVideoBtn
+        <CloseVideoBtn
           onClick={e => {
             e.preventDefault();
             e.stopPropagation();
@@ -116,7 +119,7 @@ const InGame = () => {
           }}
         >
           stop camera
-        </CloseVideoBtn> */}
+        </CloseVideoBtn>
       </Wrapper>
     </>
   );

--- a/frontend/src/pages/InGame/Mission1/Mission1.js
+++ b/frontend/src/pages/InGame/Mission1/Mission1.js
@@ -1,21 +1,23 @@
 import React, { useRef, useEffect, useContext } from 'react';
 import { GameContext } from '../../../contexts/GameContext';
 import * as pose from '@mediapipe/pose';
-import { Camera } from '@mediapipe/camera_utils';
-import { drawConnectors, drawLandmarks } from '@mediapipe/drawing_utils';
+import { estimatePose } from '../MissionEstimators/PoseEstimator';
 import styled from 'styled-components';
 
 const GameMode1MediaPipe = () => {
   const { myVideoRef } = useContext(GameContext);
   const canvasRef = useRef(null);
+  const msPoseRef = useRef(null);
 
   useEffect(() => {
-    const mpPose = new pose.Pose({
+    const videoElement = myVideoRef.current;
+
+    msPoseRef.current = new pose.Pose({
       locateFile: file =>
         `https://cdn.jsdelivr.net/npm/@mediapipe/pose/${file}`,
     });
 
-    mpPose.setOptions({
+    msPoseRef.current.setOptions({
       modelComplexity: 1,
       smoothLandmarks: true,
       enableSegmentation: true,
@@ -24,46 +26,23 @@ const GameMode1MediaPipe = () => {
       minTrackingConfidence: 0.5,
     });
 
-    mpPose.onResults(results => {
-      const canvasElement = canvasRef.current;
-      const canvasCtx = canvasElement.getContext('2d');
-      canvasElement.width = myVideoRef.current.videoWidth;
-      canvasElement.height = myVideoRef.current.videoHeight;
+    msPoseRef.current.onResults(results =>
+      estimatePose({ results, myVideoRef, canvasRef }),
+    );
 
-      canvasCtx.save();
-      canvasCtx.clearRect(0, 0, canvasElement.width, canvasElement.height);
-      canvasCtx.drawImage(
-        results.image,
-        0,
-        0,
-        canvasElement.width,
-        canvasElement.height,
-      );
+    const handleCanPlay = () => {
+      msPoseRef.current.send({ image: videoElement }).then(() => {
+        requestAnimationFrame(handleCanPlay);
+      });
+    };
 
-      drawConnectors(canvasCtx, results.poseLandmarks, pose.POSE_CONNECTIONS, {
-        color: '#FFFFFF',
-        lineWidth: 4,
-      });
-      drawLandmarks(canvasCtx, results.poseLandmarks, {
-        color: '#F0A000',
-        radius: 2,
-      });
-      canvasCtx.restore();
-    });
-
-    if (myVideoRef.current) {
-      const camera = new Camera(myVideoRef.current, {
-        onFrame: async () => {
-          await mpPose.send({ image: myVideoRef.current });
-        },
-      });
-      camera.start();
-    }
+    videoElement.addEventListener('canplay', handleCanPlay);
 
     return () => {
-      mpPose.close();
+      videoElement.removeEventListener('canplay', handleCanPlay);
+      msPoseRef.current.close();
     };
-  }, [myVideoRef.current]);
+  }, [myVideoRef]);
 
   return <Canvas ref={canvasRef} />;
 };

--- a/frontend/src/pages/InGame/Mission2/Mission2.js
+++ b/frontend/src/pages/InGame/Mission2/Mission2.js
@@ -1,123 +1,51 @@
 import React, { useEffect, useRef, useState, useContext } from 'react';
 import { GameContext } from '../../../contexts/GameContext';
-import { Camera } from '@mediapipe/camera_utils';
-import { FACEMESH_TESSELATION, Holistic } from '@mediapipe/holistic';
-import { drawConnectors } from '@mediapipe/drawing_utils';
+import { Holistic } from '@mediapipe/holistic';
+import { estimateFace } from '../MissionEstimators/FaceEstimator';
 import styled from 'styled-components';
 
 const Mission2 = () => {
   const { myVideoRef } = useContext(GameContext);
   const canvasRef = useRef(null);
-  const [score, setScore] = useState(0);
-  const [prevLeftCheekPosition, setPrevLeftCheekPosition] = useState(null);
-  const [prevRightCheekPosition, setPrevRightCheekPosition] = useState(null);
-
-  const onResults = results => {
-    if (!myVideoRef.current || !canvasRef.current) return;
-
-    const canvasElement = canvasRef.current;
-    const canvasCtx = canvasElement.getContext('2d');
-    if (canvasCtx == null) throw new Error('Could not get context');
-    canvasCtx.save();
-    canvasCtx.clearRect(0, 0, canvasElement.width, canvasElement.height);
-
-    // Only overwrite existing pixels.
-    canvasCtx.globalCompositeOperation = 'source-in';
-    canvasCtx.fillRect(0, 0, canvasElement.width, canvasElement.height);
-
-    // Only overwrite missing pixels.
-    canvasCtx.globalCompositeOperation = 'destination-atop';
-    canvasCtx.drawImage(
-      results.image,
-      0,
-      0,
-      canvasElement.width,
-      canvasElement.height,
-    );
-
-    canvasCtx.globalCompositeOperation = 'source-over';
-    drawConnectors(canvasCtx, results.faceLandmarks, FACEMESH_TESSELATION, {
-      color: '#C0C0C070',
-      lineWidth: 1,
-    });
-
-    // Check left cheek movement
-    const leftCheekIndex = 205; // Left cheek landmark index
-    const leftCheek = results.faceLandmarks[leftCheekIndex];
-    if (leftCheek) {
-      if (prevLeftCheekPosition) {
-        const deltaLeftY = leftCheek.y - prevLeftCheekPosition.y;
-        // console.log('deltaLeftY:', leftCheek.y - prevLeftCheekPosition.y);
-        if (Math.abs(deltaLeftY) > 0.01) {
-          // Threshold for detecting movement, adjust as needed
-          setScore(score => score + 1);
-        }
-      }
-      setPrevLeftCheekPosition({ x: leftCheek.x, y: leftCheek.y });
-      // console.log('prevLeftCheekPosition:', { x: leftCheek.x, y: leftCheek.y });
-    }
-
-    // Check right cheek movement
-    const rightCheekIndex = 425; // Right cheek landmark index
-    const rightCheek = results.faceLandmarks[rightCheekIndex];
-    console.log('----right cheek:  ', rightCheek);
-    if (rightCheek) {
-      // Set previous right cheek position
-      if (prevRightCheekPosition) {
-        const deltaRightY = rightCheek.y - prevRightCheekPosition.y;
-        console.log('----deltaRightY:', deltaRightY);
-        if (Math.abs(deltaRightY) > 0.01) {
-          // Threshold for detecting movement, adjust as needed
-          setScore(score => score + 1);
-        }
-      } else {
-        console.log('----계산 안 되었음!!!!!!!');
-      }
-      setPrevRightCheekPosition({ x: rightCheek.x, y: rightCheek.y });
-      console.log('prevRightCheekPosition:', {
-        x: rightCheek.x,
-        y: rightCheek.y,
-      });
-    }
-
-    canvasCtx.restore();
-  };
+  const holisticRef = useRef(null);
 
   useEffect(() => {
-    const holistic = new Holistic({
+    const videoElement = myVideoRef.current;
+
+    holisticRef.current = new Holistic({
       locateFile: file => {
         return `https://cdn.jsdelivr.net/npm/@mediapipe/holistic/${file}`;
       },
     });
 
-    holistic.setOptions({
+    holisticRef.current.setOptions({
       selfieMode: true,
-      modelComplexity: 1,
+      modelComplexity: 0.5,
       smoothLandmarks: true,
-      enableSegmentation: true,
+      enableSegmentation: false,
       smoothSegmentation: true,
       refineFaceLandmarks: true,
       minDetectionConfidence: 0.5,
       minTrackingConfidence: 0.5,
     });
 
-    holistic.onResults(onResults);
+    holisticRef.current.onResults(results =>
+      estimateFace({ results, myVideoRef, canvasRef }),
+    );
 
-    if (myVideoRef.current) {
-      const camera = new Camera(myVideoRef.current, {
-        onFrame: async () => {
-          await holistic.send({ image: myVideoRef.current });
-        },
+    const handleCanPlay = () => {
+      holisticRef.current.send({ image: videoElement }).then(() => {
+        requestAnimationFrame(handleCanPlay);
       });
-      camera.start();
-    }
+    };
+
+    videoElement.addEventListener('canplay', handleCanPlay);
 
     return () => {
-      if (holistic) {
-        holistic.close();
-      }
+      videoElement.removeEventListener('canplay', handleCanPlay);
+      holisticRef.current.close();
     };
-  }, [myVideoRef.current]);
+  }, [myVideoRef]);
 
   return <Canvas ref={canvasRef} />;
 };

--- a/frontend/src/pages/InGame/MissionEstimators/FaceEstimator.js
+++ b/frontend/src/pages/InGame/MissionEstimators/FaceEstimator.js
@@ -1,0 +1,36 @@
+import { FACEMESH_TESSELATION } from '@mediapipe/holistic';
+import { drawConnectors } from '@mediapipe/drawing_utils';
+
+export const estimateFace = ({ results, myVideoRef, canvasRef }) => {
+  if (!myVideoRef.current || !canvasRef.current) return;
+
+  const canvasElement = canvasRef.current;
+  const canvasCtx = canvasElement.getContext('2d');
+  if (canvasCtx == null) throw new Error('Could not get context');
+  canvasCtx.save();
+  canvasCtx.clearRect(0, 0, canvasElement.width, canvasElement.height);
+
+  // Only overwrite existing pixels.
+  canvasCtx.globalCompositeOperation = 'source-in';
+  canvasCtx.fillRect(0, 0, canvasElement.width, canvasElement.height);
+
+  // Only overwrite missing pixels.
+  canvasCtx.globalCompositeOperation = 'destination-atop';
+
+  canvasCtx.drawImage(
+    results.image,
+    0,
+    0,
+    canvasElement.width,
+    canvasElement.height,
+  );
+
+  canvasCtx.globalCompositeOperation = 'source-over';
+
+  drawConnectors(canvasCtx, results.faceLandmarks, FACEMESH_TESSELATION, {
+    color: '#C0C0C070',
+    lineWidth: 1,
+  });
+
+  canvasCtx.restore();
+};

--- a/frontend/src/pages/InGame/MissionEstimators/PoseEstimator.js
+++ b/frontend/src/pages/InGame/MissionEstimators/PoseEstimator.js
@@ -1,0 +1,31 @@
+import * as pose from '@mediapipe/pose';
+import { drawConnectors, drawLandmarks } from '@mediapipe/drawing_utils';
+
+export const estimatePose = ({ results, myVideoRef, canvasRef }) => {
+  const canvasElement = canvasRef.current;
+  const canvasCtx = canvasElement.getContext('2d');
+  canvasElement.width = myVideoRef.current.videoWidth;
+  canvasElement.height = myVideoRef.current.videoHeight;
+
+  canvasCtx.save();
+  canvasCtx.clearRect(0, 0, canvasElement.width, canvasElement.height);
+  canvasCtx.drawImage(
+    results.image,
+    0,
+    0,
+    canvasElement.width,
+    canvasElement.height,
+  );
+
+  drawConnectors(canvasCtx, results.poseLandmarks, pose.POSE_CONNECTIONS, {
+    color: '#FFFFFF',
+    lineWidth: 4,
+  });
+
+  drawLandmarks(canvasCtx, results.poseLandmarks, {
+    color: '#F0A000',
+    radius: 2,
+  });
+
+  canvasCtx.restore();
+};

--- a/frontend/src/pages/InGame/components/MyVideo.js
+++ b/frontend/src/pages/InGame/components/MyVideo.js
@@ -1,27 +1,9 @@
 import React, { useContext, useEffect } from 'react';
 import { GameContext } from '../../../contexts/GameContext';
-import {
-  Mission1,
-  Mission2,
-  Mission3,
-  Mission4,
-  Affirmation,
-  Result,
-} from '../';
 import styled from 'styled-components';
 
-const GAME_MODE_COMPONENTS = {
-  1: <Mission1 />,
-  2: <Mission2 />,
-  3: <Mission3 />,
-  4: <Mission4 />,
-  5: <Affirmation />,
-  6: <Result />,
-};
-
 const MyVideo = () => {
-  const { myVideoRef, myStream, setMyStream, inGameMode } =
-    useContext(GameContext);
+  const { myVideoRef, myStream, setMyStream } = useContext(GameContext);
 
   const startCamera = async () => {
     try {
@@ -49,7 +31,6 @@ const MyVideo = () => {
   return (
     <Wrapper>
       <Video ref={myVideoRef} autoPlay playsInline />
-      {GAME_MODE_COMPONENTS[inGameMode]}
     </Wrapper>
   );
 };

--- a/frontend/src/pages/InGame/components/Nav/InGameNav.js
+++ b/frontend/src/pages/InGame/components/Nav/InGameNav.js
@@ -21,6 +21,7 @@ const InGameNav = () => {
 
   const goToMain = () => {
     navigate('/main');
+    localStorage.removeItem('inGameMode');
   };
 
   useEffect(() => {}, [inGameMode]);


### PR DESCRIPTION
## Mission score 계산하는 estimator를 UI와 분리

> 작업 분류 refactor
> 

## #️⃣ Part

- [X] FE
- [ ] BE

## 📝 작업 내용

- 각 Mission별 motion, pose estimate결과가 그려지는 canvas와 logic을 분리
- MyVideo 컴포넌트의 video 태그에서 사용한 myVideoRef를 MediaPipe의 estimator에서도 같이 사용하여, camera 모듈을 중복 사용하지 않도록 일원화