### PR TITLE
Feat: 게임모드 자동 전환시 mediaPipe inference 실행

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -12,10 +12,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Jua&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR&family=Noto+Sans+KR:wght@100..900&display=swap"
     rel="stylesheet">
-  <script src="%PUBLIC_URL%/mediapipe/camera_utils/camera_utils.js" crossorigin="anonymous"></script>
-  <script src="%PUBLIC_URL%/mediapipe/drawing_utils/drawing_utils.js" crossorigin="anonymous"></script>
-  <script src="%PUBLIC_URL%/mediapipe/pose/pose.js" crossorigin="anonymous"></script>
-  <script src="%PUBLIC_URL%/mediapipe/holistic/holistic.js" crossorigin="anonymous"></script>
+
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <title>모두기상</title>
 </head>

--- a/frontend/src/contexts/ChallengeContext.js
+++ b/frontend/src/contexts/ChallengeContext.js
@@ -8,7 +8,7 @@ const ChallengeContextProvider = ({ children }) => {
   const [challengeData, setChallengeData] = useState({
     challengeId: '333',
     startDate: '2021-09-01T00:00:00.000Z',
-    wakeTime: '05:43',
+    wakeTime: '22:57',
     mates: [
       { userId: 0, userName: '천사뿅뿅뿅' },
       { userId: 1, userName: '귀요미이시현' },

--- a/frontend/src/contexts/GameContext.js
+++ b/frontend/src/contexts/GameContext.js
@@ -147,19 +147,13 @@ const GameContextProvider = ({ children }) => {
   // ------------------------------------------------
 
   useEffect(() => {
+    const OV = new OpenVidu();
     if (!connectionToken) return;
 
-    const OV = new OpenVidu();
     const newSession = OV.initSession();
     setVideoSession(newSession);
 
     console.log('session Created: ', newSession);
-    newSession.on('streamCreated', event => {
-      console.log('---Subscribe: ', event);
-      const mateStream = newSession.subscribe(event.stream, undefined);
-      setMateStreams(prevStreams => [...prevStreams, mateStream]);
-      console.log(`==== New stream created. Stream ID: ${mateStream.streamId}`);
-    });
 
     // 발행자 초기화 및 발행
     const initPublisher = () => {
@@ -182,7 +176,7 @@ const GameContextProvider = ({ children }) => {
 
     // 세션 연결
     newSession.connect(connectionToken, error => {
-      console.log('====Connection TRy: ', connectionToken);
+      console.log('====Connection Try: ', connectionToken);
       if (error) {
         console.error('Connection error:', error);
       } else {
@@ -200,7 +194,22 @@ const GameContextProvider = ({ children }) => {
         myStream.dispose();
       }
     };
-  }, [connectionToken, myVideoRef]);
+  }, [connectionToken]);
+
+  useEffect(() => {
+    if (videoSession) {
+      // videoSession.on('streamCreated', event => {
+      //   const newStream = videoSession.subscribe(event.stream, undefined);
+      //   setMateStreams(prevStreams => [...prevStreams, newStream]);
+      //   console.log(`New stream created. Stream ID: ${newStream.streamId}`);
+      // });
+      videoSession.onParticipantPublished = event => {
+        const newStream = videoSession.getRemote(event.stream, undefined);
+        setMateStreams(prevStreams => [...prevStreams, newStream]);
+        console.log(`New stream created. Stream ID: ${newStream.streamId}`);
+      };
+    }
+  }, [videoSession]);
 
   console.log('Mate Streams: ', mateStreams);
 

--- a/frontend/src/pages/InGame/InGame.js
+++ b/frontend/src/pages/InGame/InGame.js
@@ -4,8 +4,6 @@ import { ChallengeContext } from '../../contexts/ChallengeContext';
 import { UserContext } from '../../contexts/UserContext';
 import { GameContext } from '../../contexts/GameContext';
 import { isPastTime } from './functions';
-import * as pose from '@mediapipe/pose';
-import { Holistic } from '@mediapipe/holistic';
 
 import { SimpleBtn, SimpleBtn2 } from '../../components';
 

--- a/frontend/src/pages/InGame/Mission1/Mission1.js
+++ b/frontend/src/pages/InGame/Mission1/Mission1.js
@@ -1,6 +1,6 @@
-import React, { useRef, useEffect, useContext } from 'react';
+import React, { useRef, useEffect, useContext, useState } from 'react';
 import { GameContext } from '../../../contexts/GameContext';
-import * as pose from '@mediapipe/pose';
+import { Pose } from '@mediapipe/pose';
 import { estimatePose } from '../MissionEstimators/PoseEstimator';
 
 import styled from 'styled-components';
@@ -11,16 +11,13 @@ const Mission1 = () => {
   const msPoseRef = useRef(null);
 
   useEffect(() => {
-    console.log('Mission1 gameMode: ', inGameMode, 'video: ', myVideoRef);
-
-    if (inGameMode !== 1) return;
-    if (!myVideoRef.current) return;
+    if (inGameMode !== 1 || !myVideoRef.current) return;
 
     const videoElement = myVideoRef.current;
 
-    msPoseRef.current = new pose.Pose({
+    msPoseRef.current = new Pose({
       locateFile: file =>
-        `https://fastly.jsdelivr.net/npm/@mediapipe/pose/${file}`,
+        `https://cdn.jsdelivr.net/npm/@mediapipe/pose/${file}`,
     });
 
     msPoseRef.current.setOptions({
@@ -33,36 +30,37 @@ const Mission1 = () => {
       minTrackingConfidence: 0.5,
     });
 
-    console.log('msPoseRef.current: ', msPoseRef.current);
-
     msPoseRef.current.onResults(results => {
-      console.log('ms onResults: ', results);
       estimatePose({ results, myVideoRef, canvasRef });
     });
 
     const handleCanPlay = () => {
-      console.log('Mission1 handleCanPlay=========');
       let frameCount = 0;
       const frameSkip = 150;
 
       if (frameCount % (frameSkip + 1) === 0) {
-        msPoseRef.current.send({ image: videoElement }).then(() => {
-          requestAnimationFrame(handleCanPlay);
-        });
+        if (msPoseRef.current !== null) {
+          msPoseRef.current.send({ image: videoElement }).then(() => {
+            requestAnimationFrame(handleCanPlay);
+          });
+        }
       }
 
       frameCount++;
     };
 
-    videoElement.addEventListener('canplay', handleCanPlay);
+    if (videoElement.readyState >= 3) {
+      handleCanPlay();
+    } else {
+      videoElement.addEventListener('canplay', handleCanPlay);
+    }
 
     return () => {
+      msPoseRef.current = null;
       videoElement.removeEventListener('canplay', handleCanPlay);
-      msPoseRef.current.close();
     };
-  }, [myVideoRef.current, inGameMode]);
+  }, []);
 
-  console.log('----Mission1 Mounted----');
   return <Canvas ref={canvasRef} />;
 };
 

--- a/frontend/src/pages/InGame/Mission2/Mission2.js
+++ b/frontend/src/pages/InGame/Mission2/Mission2.js
@@ -11,10 +11,7 @@ const Mission2 = () => {
   const holisticRef = useRef(null);
 
   useEffect(() => {
-    console.log('Mission2 gameMode: ', inGameMode);
-
-    if (inGameMode !== 2) return;
-    if (!myVideoRef.current) return;
+    if (inGameMode !== 2 || !myVideoRef.current) return;
 
     const videoElement = myVideoRef.current;
 
@@ -27,7 +24,7 @@ const Mission2 = () => {
 
     holisticRef.current = new Holistic({
       locateFile: file => {
-        return `https://fastly.jsdelivr.net/npm/@mediapipe/holistic/${file}`;
+        return `https://cdn.jsdelivr.net/npm/@mediapipe/holistic/${file}`;
       },
     });
 
@@ -44,27 +41,32 @@ const Mission2 = () => {
     });
 
     const handleCanPlay = () => {
-      console.log('Mission2 handleCanPlay=========');
       let frameCount = 0;
       const frameSkip = 150;
 
       if (frameCount % (frameSkip + 1) === 0) {
-        holisticRef.current.send({ image: videoElement }).then(() => {
-          requestAnimationFrame(handleCanPlay);
-        });
+        if (holisticRef.current !== null) {
+          holisticRef.current.send({ image: videoElement }).then(() => {
+            requestAnimationFrame(handleCanPlay);
+          });
+        }
       }
 
       frameCount++;
     };
 
-    videoElement.addEventListener('canplay', handleCanPlay);
-    return () => {
-      videoElement.removeEventListener('canplay', handleCanPlay);
-      holisticRef.current.close();
-    };
-  }, [myVideoRef.current, inGameMode]);
+    if (videoElement.readyState >= 3) {
+      handleCanPlay();
+    } else {
+      videoElement.addEventListener('canplay', handleCanPlay);
+    }
 
-  console.log('----Mission2 Mounted----');
+    return () => {
+      holisticRef.current = null;
+      videoElement.removeEventListener('canplay', handleCanPlay);
+    };
+  }, []);
+
   return <Canvas ref={canvasRef} />;
 };
 

--- a/frontend/src/pages/InGame/Mission3/Mission3.js
+++ b/frontend/src/pages/InGame/Mission3/Mission3.js
@@ -12,7 +12,7 @@ const Mission3 = () => {
   const msPoseRef = useRef(null);
 
   useEffect(() => {
-    console.log('Mission1 gameMode: ', inGameMode, 'video: ', myVideoRef);
+    console.log('Mission3 gameMode: ', inGameMode, 'video: ', myVideoRef);
 
     if (inGameMode !== 1) return;
     if (!myVideoRef.current) return;

--- a/frontend/src/pages/InGame/components/MateVideo.js
+++ b/frontend/src/pages/InGame/components/MateVideo.js
@@ -1,56 +1,32 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState, useContext, useRef } from 'react';
 import { GameContext } from '../../../contexts/GameContext';
 import styled from 'styled-components';
 
 const MateVideo = ({ mateId, mateName }) => {
-  const { mateVideoRefs, mateStreams } = useContext(GameContext);
-  const [mateStream, setMateStream] = useState(null);
+  const { mateStreams } = useContext(GameContext);
   const [name, setName] = useState(mateName);
-  const [isActive, setIsActive] = useState(false);
-
-  useEffect(() => {
-    if (mateId && !mateVideoRefs.current[mateId]) {
-      mateVideoRefs.current[mateId] = React.createRef();
-    }
-  }, [mateId, mateVideoRefs]);
+  const mateVideoRef = useRef(null);
 
   useEffect(() => {
     if (mateStreams.length > 0) {
-      const mateStream = mateStreams.find(
-        stream => stream.connection.data.userId === mateId,
+      const thisMate = mateStreams.find(
+        sub => sub.connection.data.userId === mateId,
       );
+      setName(thisMate.connection.data.userName);
 
-      if (mateStream) {
-        setMateStream(mateStream);
-        setName(mateStream.connection.data.userName);
-        setIsActive(true);
-      } else {
-        setMateStream(null);
-        setName('');
-        setIsActive(false);
+      if (thisMate && mateVideoRef.current) {
+        thisMate.addVideoElement(mateVideoRef.current);
       }
     }
-  }, [mateStreams]);
+  }, [mateStreams, mateId]);
 
-  useEffect(() => {
-    if (mateVideoRefs.current[mateId] && mateStream) {
-      mateVideoRefs.current[mateId].srcObject = mateStream;
-      mateStream.addVideoElement(mateVideoRefs.current[mateId]);
-    }
-  }, [mateStream, mateVideoRefs.current[mateId]]);
-
-  console.log(
-    'Mate Video: ',
-    mateId,
-    mateVideoRefs.current[mateId],
-    mateStream,
-  );
+  console.log('Mate Video: ', mateId, mateStreams, mateVideoRef.current);
   return (
-    <Wrapper $mateOffLine={!mateStream}>
+    <Wrapper $mateOffLine={!mateVideoRef.current}>
       <VideoSessionArea>
-        <StatusIcon $isActive={mateStream} />
-        {mateStream ? (
-          <Video ref={mateVideoRefs.current[mateId]} autoPlay playsInline />
+        <StatusIcon $isActive={mateVideoRef.current} />
+        {mateVideoRef.current ? (
+          <Video ref={mateVideoRef.current} autoPlay playsInline />
         ) : (
           <EmptyVideo>Zzz...</EmptyVideo>
         )}


### PR DESCRIPTION
## Feat: 게임모드 자동 전환시 mediaPipe inference 실행

> 작업 분류: fix(버그 수정)

## #️⃣ Part

- [x] FE
- [ ] BE


## 📝 작업 내용
- 문제
  - GameContext의 inGameMode 전환에 따라 컴포넌트가 자동으로 마운트 될 때, mediaPipe의 inference 로직인 send 메소드가 실행되지 않음
- 원인
  - videoElement의 'canPlay' 상태일때 send 메소드가 실행될 수 있도록 설정하는 Listener가 잘 작동하고 있지 않았음
- 결과
  - videoElement가 이미 waiting room에 있을 때부터 canPlay 상태였기 때문에 listener에 넣어둔 send 메소드 관련 함수인 HandleCanPlay가 실행되지 않은 것. videoElement가 이미 원활하게 canPlay될 수 있는 상태일때도 HandleCanPlay가 작동될 수 있도록 if문 추가
