### PR TITLE
refactor: Unify Authentication & Loading page

### DIFF
--- a/frontend/src/Router.js
+++ b/frontend/src/Router.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { GameContextProvider, OpenViduContextProvider } from './contexts';
+import { Auth, Signin, Signup, ProtectedRoute } from './pages/Auth';
+import { PageNotFound } from './components';
 import {
-  Auth,
   Main,
   InGame,
   MyStreak,
@@ -9,33 +11,33 @@ import {
   JoinChallenge,
   Settings,
 } from './pages';
-import SignIn from './pages/Auth/Signin';
-import SignUp from './pages/Auth/Signup';
-import { GameContextProvider, OpenViduContextProvider } from './contexts';
 
 function Router() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Main />} />
         <Route path="/auth" element={<Auth />} />
-        <Route path="/auth/signIn" element={<SignIn />} />
-        <Route path="/auth/signUp" element={<SignUp />} />
-        <Route path="/myStreak" element={<MyStreak />} />
-        <Route path="/joinChallenge" element={<JoinChallenge />} />
-        <Route path="/createChallenge" element={<CreateChallenge />} />
-        <Route
-          path="/startMorning/:challengeId"
-          element={
-            <GameContextProvider>
-              <OpenViduContextProvider>
-                <InGame />
-              </OpenViduContextProvider>
-            </GameContextProvider>
-          }
-        />
-        <Route path="/settings" element={<Settings />} />
-        <Route path="*" element={<Main />} />
+        <Route path="/auth/signIn" element={<Signin />} />
+        <Route path="/auth/signUp" element={<Signup />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/" element={<Main />} />
+          <Route path="/main" element={<Main />} />
+          <Route path="/myStreak" element={<MyStreak />} />
+          <Route path="/joinChallenge" element={<JoinChallenge />} />
+          <Route path="/createChallenge" element={<CreateChallenge />} />
+          <Route
+            path="/startMorning/:challengeId"
+            element={
+              <GameContextProvider>
+                <OpenViduContextProvider>
+                  <InGame />
+                </OpenViduContextProvider>
+              </GameContextProvider>
+            }
+          />
+          <Route path="/settings" element={<Settings />} />
+        </Route>
+        <Route path="*" element={<PageNotFound />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/components/PageNotFound.js
+++ b/frontend/src/components/PageNotFound.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { SimpleBtn } from './';
+import * as S from '../styles/common';
+
+const PageNotFound = () => {
+  const navigate = useNavigate();
+  return (
+    <S.PageWrapper>
+      존재하지 않는 페이지 입니다.
+      <SimpleBtn btnName="홈으로" onClickHandler={() => navigate('/main')} />
+    </S.PageWrapper>
+  );
+};
+
+export default PageNotFound;

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -5,5 +5,15 @@ import InputBox from './InputBox';
 import InputLine from './InputLine';
 import Modal from './Modal';
 import NavBar from './NavBar';
+import PageNotFound from './PageNotFound';
 
-export { Icon, CardBtn, SimpleBtn, InputBox, InputLine, Modal, NavBar };
+export {
+  Icon,
+  CardBtn,
+  SimpleBtn,
+  InputBox,
+  InputLine,
+  Modal,
+  NavBar,
+  PageNotFound,
+};

--- a/frontend/src/contexts/AccountContexts.js
+++ b/frontend/src/contexts/AccountContexts.js
@@ -5,6 +5,7 @@ const AccountContext = createContext();
 
 const AccountContextProvider = ({ children }) => {
   const [accessToken, setAccessToken] = useState(null);
+  const [userId, setUserId] = useState(null);
 
   const logOut = async () => {
     try {
@@ -27,6 +28,8 @@ const AccountContextProvider = ({ children }) => {
       value={{
         setAccessToken,
         accessToken,
+        setUserId,
+        userId,
         logOut,
       }}
     >

--- a/frontend/src/contexts/ChallengeContext.js
+++ b/frontend/src/contexts/ChallengeContext.js
@@ -1,10 +1,13 @@
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
+import { AccountContext, UserContext } from './';
 import { challengeServices } from '../apis/challengeServices';
-import useCheckTime from '../hooks/useCheckTime';
 
 const ChallengeContext = createContext();
 
 const ChallengeContextProvider = ({ children }) => {
+  const { accessToken, userId } = useContext(AccountContext);
+  const { userInfo } = useContext(UserContext);
+  const { challengeId } = userInfo;
   // 임시 데이터
   const [challengeData, setChallengeData] = useState({
     challengeId: '333',
@@ -19,7 +22,7 @@ const ChallengeContextProvider = ({ children }) => {
     ],
   });
 
-  const fetchChallengeData = async ({ accessToken, challengeId }) => {
+  const fetchChallengeData = async () => {
     try {
       const response = await challengeServices.getChallengeInfo({
         accessToken: accessToken,
@@ -35,7 +38,7 @@ const ChallengeContextProvider = ({ children }) => {
     }
   };
 
-  const fetchInvitationData = async ({ accessToken, userId }) => {
+  const fetchInvitationData = async () => {
     try {
       const response = await challengeServices.getInvitationInfo({
         accessToken,

--- a/frontend/src/contexts/UserContext.js
+++ b/frontend/src/contexts/UserContext.js
@@ -5,6 +5,7 @@ import { AccountContext } from './AccountContexts';
 const UserContext = createContext();
 
 const UserContextProvider = ({ children }) => {
+  const { accessToken, userId } = useContext(AccountContext);
   // 임시 유저 정보
   const [userInfo, setUserInfo] = useState({
     userId: '',
@@ -15,10 +16,8 @@ const UserContextProvider = ({ children }) => {
     invitationCounts: 0,
     affirmation: '',
   });
-  const [userId, setUserId] = useState(null);
-  const { accessToken } = useContext(AccountContext);
 
-  const fetchUserData = async ({ accessToken, userId }) => {
+  const fetchUserData = async () => {
     try {
       const response = await userServices.getUserInfo({
         accessToken: accessToken,
@@ -31,9 +30,7 @@ const UserContextProvider = ({ children }) => {
   };
 
   return (
-    <UserContext.Provider
-      value={{ userInfo, fetchUserData, setUserInfo, userId, setUserId }}
-    >
+    <UserContext.Provider value={{ userInfo, fetchUserData, setUserInfo }}>
       {children}
     </UserContext.Provider>
   );

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -2,15 +2,14 @@ import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { authServices } from '../apis/authServices';
 import { AccountContext } from '../contexts/AccountContexts';
-import { UserContext } from '../contexts/UserContext';
 import useFetch from '../hooks/useFetch';
 
 const useAuth = () => {
   const navigate = useNavigate();
 
   const { fetchData } = useFetch();
-  const { accessToken, setAccessToken } = useContext(AccountContext);
-  const { setUserId } = useContext(UserContext);
+  const { accessToken, setAccessToken, setUserId } = useContext(AccountContext);
+
   const refreshToken = localStorage.getItem('refreshToken');
 
   const refreshAuthorization = async () => {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,11 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import Router from './Router';
 
-import {
-  AccountContextProvider,
-  UserContextProvider,
-  ChallengeContextProvider,
-} from './contexts';
+import { AccountContextProvider } from './contexts';
 
 import GlobalStyle from './styles/GlobalStyle';
 import theme from './styles/theme';
@@ -21,11 +17,7 @@ root.render(
     <GlobalStyle />
     <ThemeProvider theme={theme}>
       <AccountContextProvider>
-        <UserContextProvider>
-          <ChallengeContextProvider>
-            <Router />
-          </ChallengeContextProvider>
-        </UserContextProvider>
+        <Router />
       </AccountContextProvider>
     </ThemeProvider>
   </>,

--- a/frontend/src/pages/Auth/Auth.js
+++ b/frontend/src/pages/Auth/Auth.js
@@ -1,17 +1,15 @@
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AccountContext } from '../../contexts/AccountContexts';
-import { UserContext } from '../../contexts/UserContext';
-import { authServices } from '../../apis/authServices';
+import { AccountContext } from '../../contexts';
 import useFetch from '../../hooks/useFetch';
+import { authServices } from '../../apis/authServices';
 import { SimpleBtn } from '../../components';
 
 import * as S from '../../styles/common';
 
 const Auth = () => {
   const { accessToken, setAccessToken } = useContext(AccountContext);
-  const { userId, setUserId } = useContext(UserContext);
-  const { fetchDataWithStatus } = useFetch();
+  const { fetchData } = useFetch();
   const navigate = useNavigate();
   const deleteRefreshToken = async () => {
     try {
@@ -28,7 +26,7 @@ const Auth = () => {
   const handleLogOut = async accessToken => {
     try {
       console.log('AT', accessToken);
-      const response = await fetchDataWithStatus(() =>
+      const response = await fetchData(() =>
         authServices.logOutUser({ accessToken: accessToken }),
       );
       const {
@@ -36,7 +34,6 @@ const Auth = () => {
         data: logoutData,
         error: logoutError,
         status: logoutStatus,
-        statusText: logoutStatusText,
       } = response;
       if (logoutStatus === 200) {
         alert('로그아웃 되었습니다.');
@@ -61,8 +58,7 @@ const Auth = () => {
   useEffect(() => {
     console.log('AT', accessToken);
     console.log('RT', localStorage.getItem('refreshToken'));
-    console.log('UID', userId);
-  }, [accessToken, userId]);
+  }, [accessToken]);
 
   // if (
   //   isLoginLoading ||

--- a/frontend/src/pages/Auth/ProtectedRoute.js
+++ b/frontend/src/pages/Auth/ProtectedRoute.js
@@ -1,0 +1,50 @@
+import React, { useContext, useState, useEffect } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import {
+  AccountContext,
+  UserContextProvider,
+  ChallengeContextProvider,
+} from '../../contexts';
+import useAuth from '../../hooks/useAuth';
+
+const ProtectedRoute = () => {
+  const { accessToken, userId } = useContext(AccountContext);
+  const { handleCheckAuth } = useAuth();
+  const [isAuthorized, setIsAuthorized] = useState(false);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+
+  const checkAuthorize = async () => {
+    setIsAuthLoading(true);
+    const response = await handleCheckAuth();
+    if (response) {
+      setIsAuthLoading(false);
+      setIsAuthorized(true);
+    }
+  };
+
+  useEffect(() => {
+    checkAuthorize();
+    console.log('checking authorization...');
+    console.log('AT', accessToken);
+    console.log('RT', localStorage.getItem('refreshToken'));
+    console.log('USER ID: ', userId);
+  }, [accessToken]);
+
+  if (isAuthLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!isAuthLoading && !isAuthorized) {
+    return <Navigate to="/auth" replace />;
+  }
+
+  return (
+    <UserContextProvider>
+      <ChallengeContextProvider>
+        <Outlet />
+      </ChallengeContextProvider>
+    </UserContextProvider>
+  );
+};
+
+export default ProtectedRoute;

--- a/frontend/src/pages/Auth/index.js
+++ b/frontend/src/pages/Auth/index.js
@@ -1,0 +1,6 @@
+import Auth from './Auth';
+import Signin from './Signin';
+import Signup from './Signup';
+import ProtectedRoute from './ProtectedRoute';
+
+export { Auth, Signin, Signup, ProtectedRoute };

--- a/frontend/src/pages/JoinChallenge/JoinChallenge.js
+++ b/frontend/src/pages/JoinChallenge/JoinChallenge.js
@@ -2,50 +2,22 @@ import React, { useContext, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { NavBar, SimpleBtn } from '../../components';
 import { ChallengeContext } from '../../contexts/ChallengeContext';
-import { AccountContext } from '../../contexts/AccountContexts';
-import { UserContext } from '../../contexts/UserContext';
-import useAuth from '../../hooks/useAuth';
 import useFetch from '../../hooks/useFetch';
 
 import * as S from '../../styles/common';
 
 const JoinChallenge = () => {
-  const [isAuthorized, setIsAuthorized] = useState(false);
-  const [isAuthLoading, setIsAuthLoading] = useState(true);
+  const navigate = useNavigate();
   const [invitations, setInvitations] = useState([]);
   const [isInvitationLoading, setIsInvitationLoading] = useState(true);
 
   const { fetchInvitationData } = useContext(ChallengeContext);
-  const { accessToken } = useContext(AccountContext);
-  const { userId } = useContext(UserContext);
   const { fetchData } = useFetch();
-  const { handleCheckAuth } = useAuth();
 
-  const navigate = useNavigate();
-
-  const checkAuthorize = async () => {
-    try {
-      const response = await fetchData(() => handleCheckAuth());
-      const { isLoading: isAuthLoading, error: authError } = response;
-      if (!isAuthLoading) {
-        setIsAuthLoading(false);
-        setIsAuthorized(true);
-      } else if (authError) {
-        setIsAuthLoading(false);
-        setIsAuthorized(false);
-        navigate('/auth');
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const getInvitations = async ({ accessToken, userId }) => {
+  const getInvitations = async () => {
     setIsInvitationLoading(true);
     try {
-      const response = await fetchData(() =>
-        fetchInvitationData({ accessToken, userId }),
-      );
+      const response = await fetchData(() => fetchInvitationData());
       const {
         isLoading: isInvitationLoading,
         data: invitationData,
@@ -68,18 +40,8 @@ const JoinChallenge = () => {
   };
 
   useEffect(() => {
-    checkAuthorize();
+    getInvitations();
   }, []);
-
-  useEffect(() => {
-    if (!isAuthLoading && isAuthorized) {
-      console.log('getting invitations');
-      getInvitations({ accessToken, userId });
-    }
-  }, [isAuthLoading, isAuthorized]);
-
-  if (isAuthLoading) return <div>Loading...</div>;
-  if (!isAuthorized) return <div>Unauthorized</div>;
 
   return (
     <>

--- a/frontend/src/pages/Main/Main.js
+++ b/frontend/src/pages/Main/Main.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AccountContext, UserContext, ChallengeContext } from '../../contexts';
+import { UserContext, ChallengeContext } from '../../contexts';
 import useCheckTime from '../../hooks/useCheckTime';
-import useAuth from '../../hooks/useAuth';
 import useFetch from '../../hooks/useFetch';
 import { NavBar, CardBtn, SimpleBtn } from '../../components';
 import {
@@ -21,32 +20,29 @@ import * as S from '../../styles/common';
 
 const Main = () => {
   const { fetchData } = useFetch();
-  const { handleCheckAuth } = useAuth();
   const navigate = useNavigate();
 
-  const { accessToken } = useContext(AccountContext);
   // setUserInfo는 Test용으로 사용하는 함수
-  const { userInfo, setUserInfo, fetchUserData, userId } =
-    useContext(UserContext);
-  const { userName, challengeId: hasChallenge } = userInfo;
+  const { userInfo, setUserInfo, fetchUserData } = useContext(UserContext);
+  const { userName, challengeId } = userInfo;
+  const hasChallenge = challengeId >= 0;
   const { challengeData, setChallengeData, fetchChallengeData } =
     useContext(ChallengeContext);
-  const { challengeId } = challengeData;
+
   const { isTooEarly, isTooLate } = useCheckTime(challengeData?.wakeTime);
 
   // ---------------현재 페이지에서 쓸 State---------------
-  const [isAuthorized, setIsAuthorized] = useState(false);
-  const [isAuthLoading, setIsAuthLoading] = useState(true);
   const [isUserInfoLoading, setIsUserInfoLoading] = useState(true);
   const [isChallengeInfoLoading, setIsChallengeInfoLoading] = useState(true);
+
   const greetings = GREETINGS[0] + userName + GREETINGS[1];
 
   const CARD_CONTENTS = {
-    streak: <StreakContent userInfo={userInfo} />,
-    invitations: <InvitationsContent id={userId} />,
-    create: <CreateContent id={userId} />,
-    challenge: <ChallengeContent id={userId} data={challengeData} />,
-    enter: <EnterContent id={userId} />,
+    streak: <StreakContent />,
+    invitations: <InvitationsContent />,
+    create: <CreateContent />,
+    challenge: <ChallengeContent />,
+    enter: <EnterContent />,
   };
 
   const CARD_ON_CLICK_HANDLERS = {
@@ -80,21 +76,10 @@ const Main = () => {
     },
   };
 
-  const checkAuthorize = async () => {
-    setIsAuthLoading(true);
-    const response = await handleCheckAuth();
-    if (response) {
-      setIsAuthLoading(false);
-      setIsAuthorized(true);
-    }
-  };
-
-  const getUserInfo = async ({ accessToken, userId }) => {
+  const getUserInfo = async () => {
     setIsUserInfoLoading(true);
     try {
-      const response = await fetchData(() =>
-        fetchUserData({ accessToken, userId }),
-      );
+      const response = await fetchData(() => fetchUserData());
       const {
         isLoading: isUserInfoLoading,
         data: userInfoData,
@@ -114,12 +99,10 @@ const Main = () => {
     }
   };
 
-  const getChallengeInfo = async ({ accessToken, challengeId }) => {
+  const getChallengeInfo = async () => {
     setIsChallengeInfoLoading(true);
     try {
-      const response = await fetchData(() =>
-        fetchChallengeData({ accessToken, challengeId }),
-      );
+      const response = await fetchData(() => fetchChallengeData());
       const {
         isLoading: isChallengeInfoLoading,
         data: challengeInfoData,
@@ -138,33 +121,6 @@ const Main = () => {
       alert(error);
     }
   };
-
-  useEffect(() => {
-    checkAuthorize();
-    console.log('checking authorization...');
-    console.log('AT', accessToken);
-    console.log('RT', localStorage.getItem('refreshToken'));
-    console.log('UID', userId);
-  }, [accessToken]);
-
-  // useEffect(() => {
-  //   console.log('getting user info...');
-  //   console.log('user id is : ', userId);
-  //   if (userId && isAuthorized) {
-  //     getUserInfo({ userId });
-  //   }
-  // }, [userId, isAuthorized]);
-
-  // useEffect(() => {
-  //   if (hasChallenge && !isUserInfoLoading && isAuthorized) {
-  //     getChallengeInfo({ accessToken, challengeId });
-  //   } else {
-  //     setIsChallengeInfoLoading(false);
-  //   }
-  // }, [hasChallenge, isUserInfoLoading, isAuthorized]);
-
-  if (isAuthLoading) return <div>Loading...</div>;
-  if (!isAuthorized) return <div>접근이 허용되지 않은 페이지입니다.</div>;
 
   return (
     <>

--- a/frontend/src/pages/Main/cardComponents/StreakContent.js
+++ b/frontend/src/pages/Main/cardComponents/StreakContent.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { UserContext } from '../../../contexts/UserContext';
 import {
   level0,
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 
 const StreakContent = () => {
   const [level, setLevel] = useState('streak0');
-  const { userInfo } = React.useContext(UserContext);
+  const { userInfo } = useContext(UserContext);
   const { streakDays, medals } = userInfo;
   // calculate user streak level by user streakDays
 

--- a/frontend/src/pages/MyStreak/MyStreak.js
+++ b/frontend/src/pages/MyStreak/MyStreak.js
@@ -2,45 +2,21 @@ import React, { useContext, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { NavBar, SimpleBtn } from '../../components';
 import { UserContext } from '../../contexts/UserContext';
-import useAuth from '../../hooks/useAuth';
 import useFetch from '../../hooks/useFetch';
 
 import * as S from '../../styles/common';
 
 const MyStreak = () => {
-  const [isAuthorized, setIsAuthorized] = useState(false);
-  const [isAuthLoading, setIsAuthLoading] = useState(true);
-  const [isUserInfoLoading, setIsUserInfoLoading] = useState(true);
-  const { fetchData } = useFetch();
-  const { handleCheckAuth } = useAuth();
   const navigate = useNavigate();
-  const { userInfo, setUserInfo, fetchUserData, userId } =
-    useContext(UserContext);
-  const { userName, streakDays, medals, affirmation } = userInfo;
+  const { fetchData } = useFetch();
+  const [isUserInfoLoading, setIsUserInfoLoading] = useState(true);
+  const { userInfo, setUserInfo, fetchUserData } = useContext(UserContext);
+  const { userId, userName, streakDays, medals, affirmation } = userInfo;
 
-  const checkAuthorize = async () => {
-    try {
-      const response = await fetchData(() => handleCheckAuth());
-      const { isLoading: isAuthLoading, error: authError } = response;
-      if (!isAuthLoading) {
-        setIsAuthLoading(false);
-        setIsAuthorized(true);
-      } else if (authError) {
-        setIsAuthLoading(false);
-        setIsAuthorized(false);
-        navigate('/auth');
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const getUserInfo = async ({ accessToken, userId }) => {
+  const getUserInfo = async () => {
     setIsUserInfoLoading(true);
     try {
-      const response = await fetchData(() =>
-        fetchUserData({ accessToken, userId }),
-      );
+      const response = await fetchData(() => fetchUserData());
       const {
         isLoading: isUserInfoLoading,
         data: userInfoData,
@@ -61,17 +37,8 @@ const MyStreak = () => {
   };
 
   useEffect(() => {
-    checkAuthorize();
+    getUserInfo();
   }, []);
-
-  useEffect(() => {
-    if (userId && isAuthorized) {
-      getUserInfo({ userId });
-    }
-  }, [userId, isAuthorized]);
-
-  if (isAuthLoading || isUserInfoLoading) return <div>Loading...</div>;
-  if (!isAuthorized) return <div>접근이 허용되지 않은 페이지입니다.</div>;
 
   return (
     <>

--- a/frontend/src/pages/Settings/Settings.js
+++ b/frontend/src/pages/Settings/Settings.js
@@ -12,8 +12,7 @@ const Settings = () => {
   const [isAuthLoading, setIsAuthLoading] = useState(true);
   const [isAuthorized, setIsAuthorized] = useState(false);
   const [isLogoutLoading, setIsLogoutLoading] = useState(false);
-  const { setUserId } = useContext(UserContext);
-  const { accessToken, setAccessToken } = useContext(AccountContext);
+  const { accessToken, setAccessToken, setUserId } = useContext(AccountContext);
 
   const { fetchData } = useFetch();
   const { handleCheckAuth } = useAuth();


### PR DESCRIPTION
## 유효한 유저인지 check하는 페이지 일원화

> 작업 분류: refactor

## #️⃣ Part
- [x] FE
- [ ] BE

## 📝 작업 내용
- user의 accessToken을 검증하는 로직을 모든 페이지에서 일일이 하는 것이 아니라, 하나의 페이지에서 하고, 그 페이지를 거쳐야 우리의 main logic 페이지로 넘어갈 수 있게 Routing 조정 (ProtectedRoute 사용)
- AccountContext에서 accessToken, userId 관리