### PR TITLE
Add score state

### DIFF
--- a/frontend/src/contexts/GameContext.js
+++ b/frontend/src/contexts/GameContext.js
@@ -41,7 +41,12 @@ const GameContextProvider = ({ children }) => {
     0,
   );
 
-  const [myRoundStatus, setMyRoundStatus] = useState([]);
+  const [gameScore, setGameScore] = useState(0);
+  // Mission1, 2, 3, 4에서 축적되는 점수
+  // Affirmation Round에서 Backend로 전송하여, 모든 유저의 ranking 계산값 리턴 받기
+
+  const [rangkings, setRankings] = useState([]);
+  // [ { userId: string, userName: string, score: number } ] 형태 (sort한 상태로 받아오기)
 
   let nextGameMode = 1;
 
@@ -97,6 +102,10 @@ const GameContextProvider = ({ children }) => {
         inGameMode,
         isGameLoading,
         setIsGameLoading,
+        gameScore,
+        setGameScore,
+        rangkings,
+        setRankings,
         myMissionStatus,
         setMyMissionStatus,
         matesMissionStatus,


### PR DESCRIPTION
## 게임 Score State Context 추가

## #️⃣ Part
- [x] FE
- [ ] BE

## 📝 작업 내용
- 각 미션 별 수행 결과 점수 저장할 Context
  - const [gameScore, setGameScore] = useState(0);
  > Mission1, 2, 3, 4에서 축적되는 점수
  > Affirmation Round에서 Backend로 전송하여, 모든 유저의 ranking 계산값 리턴 받기

- 각 유저 별 게임 점수 랭킹 저장할 Context
  -  const [rangkings, setRankings] = useState([]);
  > payload: `{userId: string, score: number}`
  > response: `[ { userId: string, userName: string, score: number } ]` 형태 (내림차순으로 sort한 상태)
  @won0845 모든 client의 gameScore 값을 전달받아, 랭킹을 계산하고, 결과값을 반환해주는 API가 필요합니다.