### PR TITLE
feat: add effects to mission1 guideline and progress bar

### DIFF
--- a/frontend/src/contexts/GameContext.js
+++ b/frontend/src/contexts/GameContext.js
@@ -38,7 +38,7 @@ const GameContextProvider = ({ children }) => {
   const [isGameLoading, setIsGameLoading] = useState(false);
   const [inGameMode, setInGameMode] = useState(
     // parseInt(localStorage.getItem('inGameMode')) || 0,
-    0,
+    1,
   );
 
   const [myRoundStatus, setMyRoundStatus] = useState([]);
@@ -76,7 +76,7 @@ const GameContextProvider = ({ children }) => {
     if (challengeData && !isTooEarly && !isTooLate) {
       // ⭐️⭐️⭐️⭐️⭐️⭐️ 개발 편의 용 주석 ⭐️⭐️⭐️⭐️⭐️//
       // 나중에 다시 풀어야 함
-      scheduleFirstMission();
+      // scheduleFirstMission();
       // ===== ⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️ ==================
     }
   }, [challengeData]);

--- a/frontend/src/contexts/GameContext.js
+++ b/frontend/src/contexts/GameContext.js
@@ -37,8 +37,8 @@ const GameContextProvider = ({ children }) => {
 
   const [isGameLoading, setIsGameLoading] = useState(false);
   const [inGameMode, setInGameMode] = useState(
-    // parseInt(localStorage.getItem('inGameMode')) || 0,
-    1,
+    parseInt(localStorage.getItem('inGameMode')) || 0,
+    // 1,
   );
 
   const [myRoundStatus, setMyRoundStatus] = useState([]);
@@ -76,7 +76,7 @@ const GameContextProvider = ({ children }) => {
     if (challengeData && !isTooEarly && !isTooLate) {
       // ⭐️⭐️⭐️⭐️⭐️⭐️ 개발 편의 용 주석 ⭐️⭐️⭐️⭐️⭐️//
       // 나중에 다시 풀어야 함
-      // scheduleFirstMission();
+      scheduleFirstMission();
       // ===== ⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️ ==================
     }
   }, [challengeData]);

--- a/frontend/src/contexts/GameContext.js
+++ b/frontend/src/contexts/GameContext.js
@@ -95,6 +95,7 @@ const GameContextProvider = ({ children }) => {
     inGameMode,
     remainingTime,
     myMissionStatus,
+    gameScore,
   );
   return (
     <GameContext.Provider

--- a/frontend/src/contexts/GameContext.js
+++ b/frontend/src/contexts/GameContext.js
@@ -17,7 +17,7 @@ const GAME_MODE = {
 
 // mission 당 소요 시간
 const GAME_MODE_DURATION = {
-  1: 20000,
+  1: 21500,
   2: 15000,
   3: 17000,
   4: 15000,

--- a/frontend/src/pages/InGame/Mission1/Guide.js
+++ b/frontend/src/pages/InGame/Mission1/Guide.js
@@ -17,27 +17,29 @@ const Guide = ({ poseCorrect }) => {
   const latestPoseCorrect = useRef(poseCorrect); // useRef를 사용하여 최신 poseCorrect를 저장
 
   useEffect(() => {
-    console.log(poseCorrect, color);
-    // console.log('====================color changed===========');
+    // console.log(poseCorrect, color);
+
     if (!poseCorrect.active) {
       setColor('#F0F3FF');
     } else {
+      console.log('====================round succeeded===============');
       setColor('#15F5BA');
     }
-    latestPoseCorrect.current = poseCorrect; // 컴포넌트가 렌더링될 때마다 최신 poseCorrect로 업데이트
+    latestPoseCorrect.current = poseCorrect;
   }, [poseCorrect.active]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      console.log(latestPoseCorrect.current, color); // 항상 최신의 poseCorrect를 참조
+      // console.log(latestPoseCorrect.current, color);
       if (
         latestPoseCorrect.current.direction === 'left' &&
         !latestPoseCorrect.current.active
       ) {
+        console.log('====================round failed===============');
         setColor('#FF008F');
       }
       setTimeout(() => {
-        console.log('====================flipped===========');
+        // console.log('====================flipped===========');
         console.log('round 2 Start');
         setIsFlipped(true);
       }, time.afterCheckCorrect);

--- a/frontend/src/pages/InGame/Mission1/Guide.js
+++ b/frontend/src/pages/InGame/Mission1/Guide.js
@@ -1,5 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
+
+const time = {
+  roundFinish: 8500,
+  afterCheckCorrect: 500,
+  afterFlip: 500,
+};
 
 const Guide = ({ poseCorrect }) => {
   const [isFlipped, setIsFlipped] = useState(false);
@@ -8,21 +14,52 @@ const Guide = ({ poseCorrect }) => {
     poseCorrect.active ? '#15F5BA' : '#F0F3FF',
   );
 
+  const latestPoseCorrect = useRef(poseCorrect); // useRef를 사용하여 최신 poseCorrect를 저장
+
   useEffect(() => {
+    console.log(poseCorrect, color);
     // console.log('====================color changed===========');
     if (!poseCorrect.active) {
       setColor('#F0F3FF');
     } else {
       setColor('#15F5BA');
     }
+    latestPoseCorrect.current = poseCorrect; // 컴포넌트가 렌더링될 때마다 최신 poseCorrect로 업데이트
   }, [poseCorrect.active]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      // console.log('====================flipped===========');
-      setIsFlipped(true);
-    }, 8500);
+      console.log(latestPoseCorrect.current, color); // 항상 최신의 poseCorrect를 참조
+      if (
+        latestPoseCorrect.current.direction === 'left' &&
+        !latestPoseCorrect.current.active
+      ) {
+        setColor('#FF008F');
+      }
+      setTimeout(() => {
+        console.log('====================flipped===========');
+        console.log('round 2 Start');
+        setIsFlipped(true);
+      }, time.afterCheckCorrect);
+      setTimeout(() => {
+        setColor('#F0F3FF');
+      }, time.afterFlip);
+    }, time.roundFinish);
+    return () => clearTimeout(timer);
+  }, []);
 
+  useEffect(() => {
+    const timer = setTimeout(
+      () => {
+        if (
+          latestPoseCorrect.current.direction === 'left' &&
+          !latestPoseCorrect.current.active
+        ) {
+          setColor('#FF008F');
+        }
+      },
+      time.roundFinish * 2 + time.afterCheckCorrect + time.afterFlip,
+    );
     return () => clearTimeout(timer);
   }, []);
 
@@ -64,7 +101,7 @@ const StyledSVG = styled.svg`
   transition: 0.1s ease;
 
   path {
-    transition: fill 1s ease-in-out;
+    transition: fill 1s ease;
   }
   transform: ${({ $isFlipped }) => ($isFlipped ? 'scaleX(-1)' : 'none')};
 

--- a/frontend/src/pages/InGame/Mission1/Mission1.js
+++ b/frontend/src/pages/InGame/Mission1/Mission1.js
@@ -29,6 +29,7 @@ const Mission1 = () => {
 
   const [stretchSide, setStretchSide] = useState(round);
   const [currentRound, setCurrentRound] = useState(0);
+  const [progress, setProgress] = useState(0);
 
   useEffect(() => {
     if (
@@ -50,7 +51,11 @@ const Mission1 = () => {
         canvasRef,
         direction,
       });
-      if (result) {
+      console.log(result);
+
+      setProgress(result.currentScoreLeft);
+
+      if (result.isPoseCorrect) {
         setStretchSide(prevState =>
           prevState.map((item, index) =>
             index === currentRound ? { ...item, active: true } : item,
@@ -94,6 +99,9 @@ const Mission1 = () => {
       <GameLoading />
       {isGameLoading || (
         <>
+          <ProgressWrapper>
+            <ProgressIndicator style={{ width: `${progress}%` }} />
+          </ProgressWrapper>
           <Canvas ref={canvasRef} />
           <Guide poseCorrect={stretchSide[currentRound]} />
         </>
@@ -111,4 +119,18 @@ const Canvas = styled.canvas`
   width: 100vw;
   height: 100vh;
   object-fit: cover;
+`;
+
+const ProgressWrapper = styled.div`
+  width: 100%;
+  height: 20px;
+  background-color: #f0f3ff;
+  border-radius: 10px;
+  overflow: hidden;
+  margin: 20px 0;
+`;
+
+const ProgressIndicator = styled.div`
+  height: 100%;
+  background-color: #15f5ba;
 `;

--- a/frontend/src/pages/InGame/Mission1/Mission1.js
+++ b/frontend/src/pages/InGame/Mission1/Mission1.js
@@ -63,6 +63,7 @@ const Mission1 = () => {
         direction,
       });
 
+      // console.log('result:', result, 'direction:', direction, stretchSide);
       if (result !== undefined) {
         if (frameCount % 5 === 0) {
           requestAnimationFrame(() => updateProgress(result, direction));

--- a/frontend/src/pages/InGame/Mission1/Mission1.js
+++ b/frontend/src/pages/InGame/Mission1/Mission1.js
@@ -106,7 +106,7 @@ const Mission1 = () => {
 
   useEffect(() => {
     if (stretchSide[0].active && stretchSide[1].active) {
-      console.log('성공');
+      console.log('========미션 성공========');
       setMyMissionStatus(true);
     }
   }, [stretchSide]);

--- a/frontend/src/pages/InGame/Mission1/Mission1.js
+++ b/frontend/src/pages/InGame/Mission1/Mission1.js
@@ -13,17 +13,25 @@ const round = [
   {
     direction: 'left',
     active: false,
+    scoreAdded: false,
   },
   {
     direction: 'right',
     active: false,
+    scoreAdded: false,
   },
 ];
 
 const Mission1 = () => {
   const { poseModel } = useContext(MediaPipeContext);
-  const { isGameLoading, inGameMode, myMissionStatus, setMyMissionStatus } =
-    useContext(GameContext);
+  const {
+    isGameLoading,
+    inGameMode,
+    myMissionStatus,
+    setMyMissionStatus,
+    gameScore,
+    setGameScore,
+  } = useContext(GameContext);
   const { myVideoRef } = useContext(OpenViduContext);
   const canvasRef = useRef(null);
 
@@ -105,10 +113,27 @@ const Mission1 = () => {
   }, []);
 
   useEffect(() => {
-    if (stretchSide[0].active && stretchSide[1].active) {
-      console.log('========미션 성공========');
+    if (
+      stretchSide[0].active &&
+      stretchSide[1].active &&
+      myMissionStatus === false
+    ) {
+      console.log('========미션 1 성공========');
       setMyMissionStatus(true);
     }
+
+    stretchSide.forEach((side, index) => {
+      if (side.active && !side.scoreAdded) {
+        setGameScore(prevGameScore => prevGameScore + 12.5);
+        console.log(gameScore);
+        // 점수가 추가된 후, scoreAdded 상태 업데이트
+        setStretchSide(prevState =>
+          prevState.map((item, idx) =>
+            idx === index ? { ...item, scoreAdded: true } : item,
+          ),
+        );
+      }
+    });
   }, [stretchSide]);
 
   return (

--- a/frontend/src/pages/InGame/MissionEstimators/PoseEstimator.js
+++ b/frontend/src/pages/InGame/MissionEstimators/PoseEstimator.js
@@ -52,9 +52,9 @@ export const estimatePose = ({ results, myVideoRef, canvasRef, direction }) => {
         });
 
         if (selectedPose && selectedPose.condition(keypoints)) {
-          currentScoreLeft = currentScoreLeft + selectedPose.score;
+          currentScoreLeft += selectedPose.score;
+          currentScoreLeft = Math.min(currentScoreLeft, maxScore);
         }
-
         // console.log('currentScoreLeft:', currentScoreLeft);
 
         if (currentScoreLeft >= maxScore) {
@@ -75,7 +75,8 @@ export const estimatePose = ({ results, myVideoRef, canvasRef, direction }) => {
         });
 
         if (selectedPose && selectedPose.condition(keypoints)) {
-          currentScoreRight = currentScoreRight + selectedPose.score;
+          currentScoreRight += selectedPose.score;
+          currentScoreRight = Math.min(currentScoreRight, maxScore);
 
           // console.log('currentScoreRight:', currentScoreRight);
 
@@ -113,7 +114,14 @@ export const estimatePose = ({ results, myVideoRef, canvasRef, direction }) => {
   //   radius: 2,
   // });
 
+  const progressLeft = (currentScoreLeft / maxScore) * 100;
+  const progressRight = (currentScoreRight / maxScore) * 100;
+
   stretchingGame(results.poseLandmarks);
   canvasCtx.restore();
-  return { isPoseCorrect, currentScoreLeft, currentScoreRight };
+  return {
+    isPoseCorrect,
+    currentScoreLeft: progressLeft,
+    currentScoreRight: progressRight,
+  };
 };

--- a/frontend/src/pages/InGame/MissionEstimators/PoseEstimator.js
+++ b/frontend/src/pages/InGame/MissionEstimators/PoseEstimator.js
@@ -115,5 +115,5 @@ export const estimatePose = ({ results, myVideoRef, canvasRef, direction }) => {
 
   stretchingGame(results.poseLandmarks);
   canvasCtx.restore();
-  return isPoseCorrect;
+  return { isPoseCorrect, currentScoreLeft, currentScoreRight };
 };


### PR DESCRIPTION
## #️⃣ Part

- [X] FE
- [ ] BE

## 📝 작업 내용

### `Mission1`
모션 정확도에 따른 progress bar를 추가했습니다.
라운드 별로, 동작을 유지하지 못하였을 경우(라운드를 통과하지 못하였을 경우) 가이드라인이 빨간색으로 변하도록 하였습니다.

라운드 별 12.5점씩 `gameScore`에 더할 수 있도록 했습니다.

