### PR TITLE
Backend/feat/in game result

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/config": "^3.2.2",
         "@nestjs/core": "^10.0.0",
         "@nestjs/jwt": "^10.2.0",
+        "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.2",
@@ -1867,6 +1868,25 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/passport": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/config": "^3.2.2",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.2.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.2",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { AttendanceModule } from './attendance/attendance.module';
 import { RedisAppModule } from './redis-cache/redis-cache.module';
 import { DatabaseModule } from './database/database.module';
 import { EmailModule } from './email/email.module';
+import { InGameModule } from './in-game/in-game.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { EmailModule } from './email/email.module';
     AttendanceModule,
     DatabaseModule,
     EmailModule,
+    InGameModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/attendance/attendance.entity.ts
+++ b/backend/src/attendance/attendance.entity.ts
@@ -1,33 +1,25 @@
 import { Challenges } from 'src/challenges/challenges.entity';
 import { Users } from 'src/users/entities/users.entity';
-import {
-  Entity,
-  PrimaryGeneratedColumn,
-  Column,
-  ManyToOne,
-  JoinColumn,
-} from 'typeorm';
+import { Entity, Column, ManyToOne, JoinColumn, PrimaryColumn } from 'typeorm';
 
 @Entity()
 export class Attendance {
-  @PrimaryGeneratedColumn()
-  _id: number;
-
   @ManyToOne(() => Users, (user) => user.attendances, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' }) // 추가
   user: Users;
 
-  @Column({ name: 'user_id' })
+  @PrimaryColumn({ name: 'user_id' })
   userId: number;
 
   @ManyToOne(() => Challenges, (challenge) => challenge.attendances)
   @JoinColumn({ name: 'challenge_id' }) // 추가
   challenge: Challenges;
 
-  @Column({ name: 'challenge_id' })
+  @PrimaryColumn({ name: 'challenge_id' })
   challengeId: number;
 
-  @Column()
+  @PrimaryColumn()
+  @Column({ type: 'date' })
   date: Date;
 
   @Column()

--- a/backend/src/attendance/attendance.service.ts
+++ b/backend/src/attendance/attendance.service.ts
@@ -1,4 +1,29 @@
 import { Injectable } from '@nestjs/common';
+import { Attendance } from './attendance.entity';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ScoreDto } from 'src/in-game/dto/score.dto';
 
 @Injectable()
-export class AttendanceService {}
+export class AttendanceService {
+  constructor(
+    @InjectRepository(Attendance)
+    private attandanceRepository: Repository<Attendance>,
+  ) {
+    this.attandanceRepository = attandanceRepository;
+  }
+
+  async attend(scoreDto: ScoreDto) {
+    try {
+      const date = new Date();
+      const attendance = new Attendance();
+      attendance.userId = scoreDto.userId;
+      attendance.challengeId = scoreDto.challengeId;
+      attendance.score = scoreDto.score;
+      attendance.date = date;
+      await this.attandanceRepository.save(attendance);
+    } catch (e) {
+      console.error('Failed to save to Attend database:', e);
+    }
+  }
+}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -2,8 +2,6 @@ import {
   Body,
   Controller,
   Get,
-  HttpCode,
-  HttpException,
   HttpStatus,
   Post,
   Req,
@@ -21,7 +19,6 @@ import { UserService } from 'src/users/users.service';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { JwtRefreshGuard } from './jwt-refresh.guard';
 import * as argon2 from 'argon2';
-import RedisCacheService from 'src/redis-cache/redis-cache.service';
 
 @Controller('api/auth')
 export class AuthController {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -26,9 +26,9 @@ export class AuthService {
   }
   // 토큰 Payload에 해당하는 아아디의 유저 가져오기
   async tokenValidateUser(payload: Payload): Promise<UserDto | undefined> {
-    const user = await this.userService.findOneByID(payload.id);
+    const user = await this.userService.findOneByID(payload._id);
     if (!user) {
-      console.log('No user found with ID:', payload.id);
+      console.log('No user found with ID:', payload._id);
       throw new UnauthorizedException('User does not exist');
     }
     return user;

--- a/backend/src/auth/payload.interface.ts
+++ b/backend/src/auth/payload.interface.ts
@@ -1,5 +1,5 @@
 export interface Payload {
-  id: number;
+  _id: number;
   username: string;
   iat: number;
   exp: number;

--- a/backend/src/in-game/dto/score.dto.ts
+++ b/backend/src/in-game/dto/score.dto.ts
@@ -1,0 +1,19 @@
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class ScoreDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  challengeId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  userName: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  score: number;
+}

--- a/backend/src/in-game/in-game.controller.ts
+++ b/backend/src/in-game/in-game.controller.ts
@@ -1,0 +1,28 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Req,
+  Res,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { InGameService } from './in-game.service';
+import { AuthenticateGuard } from 'src/auth/auth.guard';
+
+@Controller('api/in-game')
+export class InGameController {
+  constructor(private readonly inGameService: InGameService) {}
+
+  @Get('enter')
+  @UseGuards(AuthenticateGuard)
+  async recordEntryTime(@Req() req, @Res() res): Promise<any> {
+    const userId = req.user._id; // 사용자 ID 추출 방법은 인증 방식에 따라 다를 수 있습니다.
+    const result = await this.inGameService.recordEntryTime(userId);
+    res.status(HttpStatus.OK).json({ suceess: result });
+  }
+}

--- a/backend/src/in-game/in-game.controller.ts
+++ b/backend/src/in-game/in-game.controller.ts
@@ -3,9 +3,6 @@ import {
   Get,
   Post,
   Body,
-  Patch,
-  Param,
-  Delete,
   Req,
   Res,
   HttpStatus,
@@ -13,8 +10,9 @@ import {
 } from '@nestjs/common';
 import { InGameService } from './in-game.service';
 import { AuthenticateGuard } from 'src/auth/auth.guard';
+import { ScoreDto } from './dto/score.dto';
 
-@Controller('api/in-game')
+@Controller('/api/in-game')
 export class InGameController {
   constructor(private readonly inGameService: InGameService) {}
 
@@ -24,5 +22,20 @@ export class InGameController {
     const userId = req.user._id; // 사용자 ID 추출 방법은 인증 방식에 따라 다를 수 있습니다.
     const result = await this.inGameService.recordEntryTime(userId);
     res.status(HttpStatus.OK).json({ suceess: result });
+  }
+
+  @Post('score')
+  async submitScore(@Body() scoreDto: ScoreDto, @Res() res) {
+    console.log(scoreDto);
+    const result = await this.inGameService.submitScore(scoreDto);
+    res.status(HttpStatus.CREATED).json({ success: result });
+  }
+
+  @Get('result')
+  @UseGuards(AuthenticateGuard)
+  async getGameResults(@Req() req, @Res() res) {
+    const challengeId = req.user.challengeId;
+    const results = await this.inGameService.getGameResults(challengeId);
+    return res.status(HttpStatus.OK).json(results);
   }
 }

--- a/backend/src/in-game/in-game.module.ts
+++ b/backend/src/in-game/in-game.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 import { InGameService } from './in-game.service';
 import { InGameController } from './in-game.controller';
+import { RedisAppModule } from 'src/redis-cache/redis-cache.module';
+import { AttendanceModule } from 'src/attendance/attendance.module';
+import { UserModule } from 'src/users/users.module';
 
 @Module({
+  imports: [RedisAppModule, AttendanceModule, UserModule],
   controllers: [InGameController],
   providers: [InGameService],
 })

--- a/backend/src/in-game/in-game.module.ts
+++ b/backend/src/in-game/in-game.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { InGameService } from './in-game.service';
+import { InGameController } from './in-game.controller';
+
+@Module({
+  controllers: [InGameController],
+  providers: [InGameService],
+})
+export class InGameModule {}

--- a/backend/src/in-game/in-game.service.ts
+++ b/backend/src/in-game/in-game.service.ts
@@ -17,7 +17,7 @@ export class InGameService {
     const result = await this.redisService.set(
       `entryTime:${userId}`,
       timestamp,
-      300,
+      900,
     );
     console.log('result:', result);
     return true;
@@ -53,7 +53,7 @@ export class InGameService {
           console.error('Failed to save to database:', e);
         });
       this.redisService
-        .expire(challengeId.toString(), 300)
+        .expire(challengeId.toString(), 900)
         .then(() => console.log('expire set Success'))
         .catch((e) => {
           console.error('Failed to set expire:', e);

--- a/backend/src/in-game/in-game.service.ts
+++ b/backend/src/in-game/in-game.service.ts
@@ -1,13 +1,103 @@
 import { Injectable } from '@nestjs/common';
 import RedisCacheService from 'src/redis-cache/redis-cache.service';
+import { ScoreDto } from './dto/score.dto';
+import { AttendanceService } from 'src/attendance/attendance.service';
+import { UserService } from 'src/users/users.service';
 
 @Injectable()
 export class InGameService {
-  constructor(private redisService: RedisCacheService) {}
+  constructor(
+    private redisService: RedisCacheService,
+    private attendanceService: AttendanceService,
+    private userService: UserService,
+  ) {}
 
-  async recordEntryTime(userId: number) {
+  async recordEntryTime(userId: number): Promise<boolean> {
     const timestamp = Date.now().toString();
-    await this.redisService.set(`entryTime:${userId}`, timestamp, 180);
+    const result = await this.redisService.set(
+      `entryTime:${userId}`,
+      timestamp,
+      300,
+    );
+    console.log('result:', result);
     return true;
+  }
+
+  async submitScore(scoreDto: ScoreDto): Promise<boolean> {
+    const { userId, userName, score, challengeId } = scoreDto;
+    try {
+      const entryTime = await this.redisService.get(`entryTime:${userId}`);
+      if (!entryTime) {
+        console.error('Entry time not found');
+        return false;
+      }
+      const currentTime = Date.now();
+      const timeScore = currentTime - parseInt(entryTime, 10);
+      const redisScore = parseFloat(`${score}.${timeScore}`);
+
+      // 점수와 입장 시간을 기반으로 추가 로직 처리
+      await this.redisService.zadd(
+        `challengeId:${challengeId}`,
+        redisScore,
+        `${userId}:${userName}`,
+      );
+      // DB 저장을 비동기적으로 수행
+      this.retryOperation(() => this.userService.setStreak(userId))
+        .then(() => console.log('Streak Save Success'))
+        .catch((e) => {
+          console.error('Failed to save to Streak:', e);
+        });
+      this.retryOperation(() => this.attendanceService.attend(scoreDto))
+        .then(() => console.log('Database Save Success'))
+        .catch((e) => {
+          console.error('Failed to save to database:', e);
+        });
+      this.redisService
+        .expire(challengeId.toString(), 300)
+        .then(() => console.log('expire set Success'))
+        .catch((e) => {
+          console.error('Failed to set expire:', e);
+        });
+      return true;
+    } catch (redisError) {
+      console.error('Redis save error:', redisError);
+      return false; // Redis 에러 시 false 반환
+    }
+  }
+
+  async getGameResults(challengeId): Promise<any> {
+    // 랭킹 데이터 조회
+    const datalist = await this.redisService.zrevrange(
+      `challengeId:${challengeId}`,
+      0,
+      -1,
+    );
+    return this.arrayToObject(datalist);
+  }
+
+  arrayToObject(array) {
+    let results = [];
+    for (let i = 0; i < array.length; i += 2) {
+      const [userId, userName] = array[i].split(':');
+      results.push({
+        userId: parseInt(userId, 10),
+        userName: userName,
+        score: parseInt(array[i + 1], 10),
+      });
+    }
+    return results;
+  }
+
+  async retryOperation(operation, retries = 3) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (retries > 0) {
+        console.log(`Retrying operation, attempts left: ${retries}`);
+        await new Promise((resolve) => setTimeout(resolve, 1000)); // 1초 대기
+        return this.retryOperation(operation, retries - 1);
+      }
+      throw error; // 모든 재시도 실패 후 에러를 throw
+    }
   }
 }

--- a/backend/src/in-game/in-game.service.ts
+++ b/backend/src/in-game/in-game.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import RedisCacheService from 'src/redis-cache/redis-cache.service';
+
+@Injectable()
+export class InGameService {
+  constructor(private redisService: RedisCacheService) {}
+
+  async recordEntryTime(userId: number) {
+    const timestamp = Date.now().toString();
+    await this.redisService.set(`entryTime:${userId}`, timestamp, 180);
+    return true;
+  }
+}

--- a/backend/src/in-game/in-game.service.ts
+++ b/backend/src/in-game/in-game.service.ts
@@ -3,7 +3,7 @@ import RedisCacheService from 'src/redis-cache/redis-cache.service';
 import { ScoreDto } from './dto/score.dto';
 import { AttendanceService } from 'src/attendance/attendance.service';
 import { UserService } from 'src/users/users.service';
-
+const EXPIRE_TIME = 900; // redis key 만료 시간
 @Injectable()
 export class InGameService {
   constructor(
@@ -11,13 +11,12 @@ export class InGameService {
     private attendanceService: AttendanceService,
     private userService: UserService,
   ) {}
-
   async recordEntryTime(userId: number): Promise<boolean> {
     const timestamp = Date.now().toString();
     const result = await this.redisService.set(
       `entryTime:${userId}`,
       timestamp,
-      900,
+      EXPIRE_TIME,
     );
     console.log('result:', result);
     return true;
@@ -53,7 +52,7 @@ export class InGameService {
           console.error('Failed to save to database:', e);
         });
       this.redisService
-        .expire(challengeId.toString(), 900)
+        .expire(challengeId.toString(), EXPIRE_TIME)
         .then(() => console.log('expire set Success'))
         .catch((e) => {
           console.error('Failed to set expire:', e);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,10 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ConfigService } from '@nestjs/config';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   const port = configService.get<number>('NEST_PORT');
   app.enableCors({
     origin: '*',

--- a/backend/src/redis-cache/redis-cache.service.ts
+++ b/backend/src/redis-cache/redis-cache.service.ts
@@ -1,6 +1,4 @@
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Cache } from 'cache-manager';
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRedis } from '@nestjs-modules/ioredis';
 import Redis from 'ioredis';
 
@@ -25,21 +23,24 @@ export class RedisCacheService {
     await this.redis.set(key, currentTime);
     return `current time: ${currentTime}`;
   }
+
+  async expire(key: string, ttl: number): Promise<number> {
+    return await this.redis.expire(key, ttl);
+  }
   async del(key: string): Promise<number> {
     return await this.redis.del(key);
   }
 
-  // async get(key: string): Promise<any> {
-  // 	return this.cacheManager.get(key);
-  // }
+  async zadd(key: string, score: number, member: string): Promise<number> {
+    return await this.redis.zadd(key, score, member);
+  }
 
-  // async set(key: string, value: any, ttl?: number): Promise<'OK' | void> {
-  // 	console.log(`Setting TTL for ${key} to ${ttl ?? 100} seconds.`);
-  // 	return await this.cacheManager.set(key, value, 100);
-  // }
-
-  // async del(key: string): Promise<number | void> {
-  // 	return this.cacheManager.del(key);
-  // }
+  async zrevrange(
+    groupKey: string,
+    start: number,
+    stop: number,
+  ): Promise<string[]> {
+    return await this.redis.zrevrange(groupKey, start, stop, 'WITHSCORES');
+  }
 }
 export default RedisCacheService;


### PR DESCRIPTION
## #️⃣ Part

- [ ] FE
- [x] BE

## 📝 작업 내용
1.  authcontroller내 안쓰는 코드 삭제
2. InGame Module 추가 및 입장시간 redis 저장
3. 클라이언트로 부터 받아오는값 전역적으로 유효성 검사
4. 로그인시 accessToken에서 유저정보 제대로 못 받아오는거 수정
5. 참석날짜 YYYY-mm-DD" 형식으로 DB에 저장 하도록 entity 수정
6. 참석 정보 유저는 하루에 하나만 입력가능하도록 primary키 수정
7.  서버에 점수 저장
   - 입장 시간을 기반으로 동점자 구분
   - redis점수 저장 후 비동기적으로 스트릭, 참석결과 DB에 저장
      - db저장 실패시 3회 재시도
   - 랭킹결과 및 입장시간 유효기간 3분 설정
   -
8.  게임 결과 조회
   - redis 키값 json으로 불가능하여 `${id}:${name}` 형식으로 키를 구성하고 받아올 때 분할하여 id,name, score 반환
   - array로 온 값 json형식으로 변환하여 반환
