### PR TITLE
UI: Settings- Refresh btn & InGame - Nav Bar zIndex & inGame - Result userName

### DIFF
--- a/frontend/src/components/Icon.js
+++ b/frontend/src/components/Icon.js
@@ -7,8 +7,6 @@ import {
   faUser,
   faSignOutAlt,
   faUserCheck,
-  faTrashCan,
-  faSadTear,
   faSpinner,
   faGear,
   faMicrophone,
@@ -20,6 +18,7 @@ import {
   faXmark,
   faFaceFrown,
   faFaceSmile,
+  faArrowsRotate,
 } from '@fortawesome/free-solid-svg-icons';
 
 import noMusic from '../assets/icons/musicOff.svg';
@@ -30,8 +29,6 @@ const iconList = {
   login: faUserCheck,
   logout: faSignOutAlt,
   user: faUser,
-  trash: faTrashCan,
-  sadFace: faSadTear,
   loading: faSpinner,
   settings: faGear,
   musicOn: faMusic,
@@ -44,6 +41,7 @@ const iconList = {
   frown: faFaceFrown,
   search: faMagnifyingGlass,
   close: faXmark,
+  refresh: faArrowsRotate,
 };
 
 const iconStyleSample = {

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -74,8 +74,6 @@ const NavBar = () => {
     }
   }, [params]);
 
-  console.log(pageType, hasLeftBtn, hasRightBtn);
-
   return (
     <Wrapper $hasLeftBtn={hasLeftBtn} $hasRightBtn={hasRightBtn}>
       {hasLeftBtn && (

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -1,10 +1,19 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { UserContext } from '../contexts';
+import { UserContext, ChallengeContext } from '../contexts';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { RoundBtn } from '../components';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
+
+const PAGE_TYPES = [
+  'main',
+  'myStreak',
+  'joinChallenge',
+  'createChallenge',
+  'settings',
+];
 
 const NavBar = () => {
+  const { getChallengeData } = useContext(ChallengeContext);
   const { myData } = useContext(UserContext);
   const { userName } = myData;
   const { pathname } = useLocation();
@@ -13,6 +22,19 @@ const NavBar = () => {
   const [hasLeftBtn, setHasLeftBtn] = useState(false);
   const [hasRightBtn, setHasRightBtn] = useState(true);
   const [pageType, setPageType] = useState('main');
+
+  const goBack = () => {
+    navigate('/');
+  };
+
+  const goToSettings = () => {
+    navigate('/settings');
+  };
+
+  const RIGHT_BTN_FUNCS = {
+    main: goToSettings,
+    settings: getChallengeData,
+  };
 
   const TITLE_BY_PAGE_TYPE = {
     main: (
@@ -27,22 +49,20 @@ const NavBar = () => {
     settings: '설정',
   };
 
-  const goBack = () => {
-    navigate('/');
-  };
-
-  const goToSettings = () => {
-    navigate('/settings');
-  };
-
   useEffect(() => {
-    const page = pathname.split('/')[1];
+    let page = pathname.split('/')[1];
+    if (page === undefined || page === '') {
+      page = 'main';
+    }
 
-    if (page) {
+    if (PAGE_TYPES.includes(page)) {
       setPageType(page);
 
       if (page === 'main') {
         setHasLeftBtn(false);
+        setHasRightBtn(true);
+      } else if (page === 'settings') {
+        setHasLeftBtn(true);
         setHasRightBtn(true);
       } else {
         setHasLeftBtn(true);
@@ -50,9 +70,11 @@ const NavBar = () => {
       }
     } else {
       setHasLeftBtn(false);
-      setHasRightBtn(true);
+      setHasRightBtn(false);
     }
   }, [params]);
+
+  console.log(pageType, hasLeftBtn, hasRightBtn);
 
   return (
     <Wrapper $hasLeftBtn={hasLeftBtn} $hasRightBtn={hasRightBtn}>
@@ -60,10 +82,15 @@ const NavBar = () => {
         <RoundBtn btnStyle={BACK_BTN_STYLE} onClickHandler={goBack} />
       )}
 
-      <Title $hasLeftBtn={hasLeftBtn}>{TITLE_BY_PAGE_TYPE[pageType]}</Title>
+      <Title $hasLeftBtn={hasLeftBtn} $hasRightBtn={hasRightBtn}>
+        {TITLE_BY_PAGE_TYPE[pageType]}
+      </Title>
 
       {hasRightBtn && (
-        <RoundBtn btnStyle={SETTINGS_BTN_STYLE} onClickHandler={goToSettings} />
+        <RoundBtn
+          btnStyle={RIGHT_BTN_STYLES[pageType]}
+          onClickHandler={RIGHT_BTN_FUNCS[pageType]}
+        />
       )}
     </Wrapper>
   );
@@ -90,8 +117,12 @@ const Wrapper = styled.nav`
 `;
 
 const Title = styled.header`
-  justify-self: ${({ $hasLeftBtn }) => ($hasLeftBtn ? 'center' : 'flex-start')};
-  margin-left: ${({ $hasLeftBtn }) => $hasLeftBtn && '-40px'};
+  justify-self: ${({ $hasLeftBtn, $hasRightBtn }) =>
+    !$hasLeftBtn && $hasRightBtn ? 'flex-start' : 'center'};
+  margin-left: ${({ $hasLeftBtn, $hasRightBtn }) =>
+    $hasLeftBtn && !$hasRightBtn && '-40px'};
+  margin-right: ${({ $hasLeftBtn, $hasRightBtn }) =>
+    !$hasLeftBtn && $hasRightBtn && '0px'};
   margin-bottom: -8px;
 
   ${({ theme }) => theme.fonts.JuaSmall}
@@ -123,4 +154,20 @@ const SETTINGS_BTN_STYLE = {
     color: 'white',
     hoverColor: 'purple',
   },
+};
+
+const REFRESH_BTN_STYLE = {
+  size: 40,
+  disabled: false,
+  icon: 'refresh',
+  iconStyle: {
+    size: 20,
+    color: 'white',
+    hoverColor: 'purple',
+  },
+};
+
+const RIGHT_BTN_STYLES = {
+  main: SETTINGS_BTN_STYLE,
+  settings: REFRESH_BTN_STYLE,
 };

--- a/frontend/src/contexts/ChallengeContext.js
+++ b/frontend/src/contexts/ChallengeContext.js
@@ -25,7 +25,7 @@ const ChallengeContextProvider = ({ children }) => {
     // ],
   });
 
-  const getChallenge = async () => {
+  const getChallengeData = async () => {
     const response = await fetchData(() =>
       challengeServices.getChallengeInfo({
         accessToken,
@@ -96,7 +96,7 @@ const ChallengeContextProvider = ({ children }) => {
 
   useEffect(() => {
     if (challengeId !== -1) {
-      getChallenge();
+      getChallengeData();
     }
   }, [challengeId]);
 
@@ -105,6 +105,7 @@ const ChallengeContextProvider = ({ children }) => {
       value={{
         challengeData,
         setChallengeData,
+        getChallengeData,
         handleCreateChallenge,
         handleAcceptInvitation,
       }}

--- a/frontend/src/pages/InGame/Result/Result.js
+++ b/frontend/src/pages/InGame/Result/Result.js
@@ -36,7 +36,6 @@ const GAME_MODE = {
 const HEADER_TEXT = '오늘의 미라클 메이커';
 
 const Result = () => {
-  const EffectCanvasRef = useRef(null);
   const { fetchData } = useFetch();
   const { accessToken, userId: myId } = useContext(AccountContext);
   const { challengeId } = useContext(UserContext);
@@ -159,7 +158,6 @@ const Result = () => {
   return (
     <>
       <Wrapper $hasRest={theRestUsersStream?.length > 0}>
-        {/* <EffectCanvas ref={EffectCanvasRef} /> */}
         <UpperArea>
           {(!theTopUserData || !theRestUsersStream) && (
             <LoadingWithText loadingMSG="결과를 불러오는 중입니다" />
@@ -203,14 +201,14 @@ const Result = () => {
               gameResults?.map(({ userName, score }, idx) => (
                 <RankingWrapper key={idx}>
                   <ScoreLine
-                    $scoreWidth={score < 30 ? 29 : score * 1.05}
+                    $scoreWidth={score < 31 ? 31 : score}
                     $isTheTop={idx === 0}
                   >
                     <RangkingAndScore>
                       <RankingNum>{idx + 1}</RankingNum>
                       <Score>{score}점</Score>
                     </RangkingAndScore>
-                    {score >= 61 && (
+                    {score >= 60 && (
                       <AllInLine>
                         <UserName>{userName}</UserName>
                         <UserProfile
@@ -218,8 +216,8 @@ const Result = () => {
                         />
                       </AllInLine>
                     )}
-                    {score < 61 && score >= 36 && (
-                      <ProfileInLine>
+                    {score < 60 && score >= 41 && (
+                      <ProfileInLine $scoreWidth={score}>
                         <UserProfile
                           $profileInline={true}
                           src={`https://api.dicebear.com/8.x/open-peeps/svg?seed=${userName}`}
@@ -228,8 +226,11 @@ const Result = () => {
                       </ProfileInLine>
                     )}
                   </ScoreLine>
-                  {score < 35 && (
-                    <ProfileOutLine $profileInline={false}>
+                  {score < 41 && (
+                    <ProfileOutLine
+                      $profileInline={false}
+                      $scoreWidth={score < 31 ? 31 : score}
+                    >
                       <UserProfile
                         $profileInline={false}
                         src={`https://api.dicebear.com/8.x/open-peeps/svg?seed=${userName}`}
@@ -418,7 +419,7 @@ const Medal = styled.img`
 const Rankings = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 50px;
+  gap: 12px;
 
   width: 100%;
   height: 50%;
@@ -428,14 +429,9 @@ const Rankings = styled.div`
 const RankingWrapper = styled.div`
   position: relative;
   width: 100%;
-  ${({ theme }) => theme.flex.between};
-  align-items: center;
 `;
 
 const ScoreLine = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
   width: ${({ $scoreWidth }) => $scoreWidth}%;
 
   ${({ theme }) => theme.flex.between};
@@ -495,7 +491,7 @@ const AllInLine = styled.div`
 
 const ProfileInLine = styled.div`
   position: absolute;
-  left: 90px;
+  left: calc(${({ $scoreWidth }) => $scoreWidth}% - 34px);
   width: 100%;
 
   ${({ theme }) => theme.flex.right};
@@ -512,7 +508,7 @@ const ProfileOutLine = styled.div`
 
   position: absolute;
   top: 0;
-  left: 110px;
+  left: calc(${({ $scoreWidth }) => $scoreWidth}% + 10px);
 
   margin-right: 8px;
 

--- a/frontend/src/pages/InGame/components/Nav/InGameNav.js
+++ b/frontend/src/pages/InGame/components/Nav/InGameNav.js
@@ -98,7 +98,7 @@ const InGameNav = () => {
 export default InGameNav;
 
 const Wrapper = styled.nav`
-  z-index: 100;
+  z-index: 900;
   position: fixed;
   top: 0;
 

--- a/frontend/src/pages/Main/cardComponents/StreakContent.js
+++ b/frontend/src/pages/Main/cardComponents/StreakContent.js
@@ -24,9 +24,9 @@ const StreakContent = ({ isWaitingRoom, userData }) => {
   const getStreakLevel = streakDays => {
     if (streakDays < 7) {
       return 'streak0';
-    } else if (streakDays >= 7 && streakDays <= 60) {
+    } else if (streakDays >= 7 && streakDays < 100) {
       return 'streak1';
-    } else if (streakDays >= 61 && streakDays <= 350) {
+    } else if (streakDays >= 100 && streakDays < 365) {
       return 'streak2';
     }
     // } else if (streakDays >= 61 && streakDays <= 90) {

--- a/frontend/src/pages/Settings/Settings.js
+++ b/frontend/src/pages/Settings/Settings.js
@@ -1,6 +1,6 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AccountContext } from '../../contexts';
+import { AccountContext, ChallengeContext, UserContext } from '../../contexts';
 import { authServices, userServices } from '../../apis';
 import useFetch from '../../hooks/useFetch';
 import { NavBar, Icon, OutlineBox, LongBtn, InputBox } from '../../components';
@@ -8,17 +8,18 @@ import * as S from '../../styles/common';
 import styled from 'styled-components';
 
 const Settings = () => {
-  const [isLogoutLoading, setIsLogoutLoading] = useState(false);
-  const [affirmation, setAffirmation] = useState('');
+  const { fetchData } = useFetch();
+  const navigate = useNavigate();
+
+  const { getUserData } = useContext(UserContext);
+  const { challengeData } = useContext(ChallengeContext);
   const { accessToken, setAccessToken, setUserId, userId } =
     useContext(AccountContext);
 
+  const [isLogoutLoading, setIsLogoutLoading] = useState(false);
+  const [affirmation, setAffirmation] = useState('');
   const [wakeTime, setWakeTime] = useState('');
   const [challengeId, setChallengeId] = useState('');
-  const { challengeData } = useContext(AccountContext);
-
-  const { fetchData } = useFetch();
-  const navigate = useNavigate();
 
   const handleLogOut = async () => {
     setIsLogoutLoading(true);
@@ -86,6 +87,12 @@ const Settings = () => {
       alert(changeWakeTimeError);
     }
   };
+
+  useEffect(() => {
+    if (accessToken && userId) {
+      getUserData();
+    }
+  }, [challengeData]);
 
   return (
     <>

--- a/frontend/src/pages/Settings/Settings.js
+++ b/frontend/src/pages/Settings/Settings.js
@@ -11,7 +11,7 @@ const Settings = () => {
   const { fetchData } = useFetch();
   const navigate = useNavigate();
 
-  const { getUserData } = useContext(UserContext);
+  const { getMyData } = useContext(UserContext);
   const { challengeData } = useContext(ChallengeContext);
   const { accessToken, setAccessToken, setUserId, userId } =
     useContext(AccountContext);
@@ -90,7 +90,7 @@ const Settings = () => {
 
   useEffect(() => {
     if (accessToken && userId) {
-      getUserData();
+      getMyData();
     }
   }, [challengeData]);
 


### PR DESCRIPTION
## 각종 스타일 조정

> 작업 분류: UI

## #️⃣ Part
- [x] FE
- [ ] BE

## 🔎 연관된 이슈
close #118 Result 화면에서 순위별 사용자 이름과 점수 부분이 깨지는 문제 

## 📝 작업 내용
- Settings Page 우측 상단에 refresh 버튼 추가하여, challenge data 새롭게 받아오도록 함
  - 새로고침 자체를 넣지 않은 이유는 곧 inGame 첫미션 시작할때 모델 로딩을 넣을 거라서 새로고침이 필요 없음
- InGame에서 게임시작되면 NavBar의 음소거 버튼 안눌리던 문제 해결
- InGame에서 Result 화면의 순위별 사용자 이름과 점수 부분이 깨지는 문제 해결
  - 현재 점수의 비율에 맞춰서 score bar를 색칠하고 있는데, 그 점수에 따라 프로필 사진과 이름의 위치를 3가지 분기로 나눠서 스타일을 처리하고 있음
  - 그런데 이름길이가 다양해지면 또 다른 로직을 추가해야 해서, 일단 사용자 이름은 무조건 3글자로 쓰기로...
  
### 스크린샷 (선택)
![image](https://github.com/TeamMoHead/ModuGisang/assets/68367393/026b8daa-c7a8-4e1d-b42a-83b5aa2b23da)
