### PR TITLE
fix: inGame result 유저 닉네임 글자수 개선 및 마이너 이슈 수정

### DIFF
--- a/frontend/src/pages/CreateChallenge/CreateChallenge.js
+++ b/frontend/src/pages/CreateChallenge/CreateChallenge.js
@@ -220,7 +220,7 @@ const CreateChallenge = () => {
                   <Day>
                     {range[0].getMonth() +
                       1 +
-                      ' 월 ' +
+                      '월 ' +
                       range[0].getDate() +
                       '일'}
                   </Day>
@@ -231,7 +231,7 @@ const CreateChallenge = () => {
                   <Day>
                     {range[1].getMonth() +
                       1 +
-                      ' 월 ' +
+                      '월 ' +
                       range[1].getDate() +
                       '일'}
                   </Day>

--- a/frontend/src/pages/InGame/Result/Result.js
+++ b/frontend/src/pages/InGame/Result/Result.js
@@ -210,14 +210,14 @@ const Result = () => {
               gameResults?.map(({ userName, score }, idx) => (
                 <RankingWrapper key={idx}>
                   <ScoreLine
-                    $scoreWidth={score < 31 ? 31 : score}
+                    $scoreWidth={score < 35 ? 35 : score}
                     $isTheTop={idx === 0}
                   >
                     <RangkingAndScore>
                       <RankingNum>{idx + 1}</RankingNum>
                       <Score>{score}점</Score>
                     </RangkingAndScore>
-                    {score >= 60 && (
+                    {score >= 65 && (
                       <AllInLine>
                         <UserName>{userName}</UserName>
                         <UserProfile
@@ -225,7 +225,7 @@ const Result = () => {
                         />
                       </AllInLine>
                     )}
-                    {score < 60 && score >= 41 && (
+                    {score < 65 && score >= 41 && (
                       <ProfileInLine $scoreWidth={score}>
                         <UserProfile
                           $profileInline={true}
@@ -238,7 +238,7 @@ const Result = () => {
                   {score < 41 && (
                     <ProfileOutLine
                       $profileInline={false}
-                      $scoreWidth={score < 31 ? 31 : score}
+                      $scoreWidth={score < 35 ? 35 : score}
                     >
                       <UserProfile
                         $profileInline={false}


### PR DESCRIPTION
## #️⃣ Part
- [x] FE
- [ ] BE

## 📝 작업 내용
- 결과창 ui에서 낮은 해상도일 때 글자수에 따라 UI가 깨지지 않도록 점수 기준을 수정했습니다. (경원님과 화면을 보며 논의해 문제 없어 보이는 점수로 수정했는데, 혹시 se로 테스트시 ui 깨짐 발생하면 말씀부탁드립니다!)
- 챌린지 생성 ui 내 띄어쓰기가 어색한 부분 수정했습니다 ('10 월 1일' 형태로 나오던 거 '10월 1일'처럼 나오도록)