### PR TITLE
Add: challenge 완료 여부 체크 api 연동

### DIFF
--- a/backend/src/challenges/challenges.controller.ts
+++ b/backend/src/challenges/challenges.controller.ts
@@ -30,6 +30,7 @@ export class ChallengesController {
     private readonly challengeService: ChallengesService,
     private readonly redisService: RedisCacheService,
   ) {}
+
   @Get()
   async getChallengeInfo(
     @Query('challengeId') challengeId: number,
@@ -40,6 +41,7 @@ export class ChallengesController {
     }
     return challenge;
   }
+
   @Post('create')
   async createChallenge(@Body() createChallengeDto: CreateChallengeDto) {
     console.log('create');
@@ -71,6 +73,7 @@ export class ChallengesController {
       }
     }
   }
+
   @Post('edit')
   async editChallenge(@Body() editChallengeDto: EditChallengeDto) {
     console.log('edit');
@@ -78,6 +81,7 @@ export class ChallengesController {
       await this.challengeService.editChallenge(editChallengeDto);
     return challenge;
   }
+
   @Post('delete/:challengeId/:hostId') // 챌린지 생성하고 시작하지 않고 삭제하는 경우
   async deleteChallenge(
     @Param('challengeId') challengeId: number,
@@ -111,6 +115,7 @@ export class ChallengesController {
       challengeId,
       userId,
     );
+
     if (result === true) {
       return {
         completed: true,
@@ -136,12 +141,14 @@ export class ChallengesController {
       isEngaged: result,
     };
   }
+
   @Get('invitations')
   getInvitations(@Query('guestId') guestId: number) {
     console.log(guestId);
     const invitations = this.challengeService.getInvitations(guestId);
     return invitations; // 데이터 반환 값 수정 예정
   }
+
   @Post('accept-invitation')
   async acceptInvitation(@Body() acceptInvitationDto: AcceptInvitationDto) {
     const result =
@@ -184,6 +191,7 @@ export class ChallengesController {
       throw new InternalServerErrorException('An unexpected error occurred');
     }
   }
+
   @Post('/changeWakeTime')
   async setChallengeWakeTime(@Body() setChallengeWakeTimeDto): Promise<void> {
     console.log('기상시간 변경완료');

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -292,6 +292,7 @@ export class ChallengesService {
     const challengeResponse: ChallengeResponseDto = {
       challengeId: challenge._id,
       startDate: challenge.startDate,
+      endDate: challenge.endDate,
       hostId: challenge.hostId,
       wakeTime: challenge.wakeTime,
       duration: challenge.duration,
@@ -556,6 +557,7 @@ export class ChallengesService {
       );
     }
   }
+
   async redisCheckChallenge(challengeId: number) {
     const challenge = await this.redisCacheService.get(
       `challenge_${challengeId}`,
@@ -567,6 +569,7 @@ export class ChallengesService {
     console.log('redis에 challenge 정보가 있습니다.');
     return JSON.parse(challenge);
   }
+
   validateChallengeDate(currentDate, challenge) {
     if (currentDate < challenge.startDate || currentDate > challenge.endDate) {
       return false;

--- a/backend/src/challenges/dto/challengeResponse.dto.ts
+++ b/backend/src/challenges/dto/challengeResponse.dto.ts
@@ -1,6 +1,7 @@
 export class ChallengeResponseDto {
   challengeId: number;
   startDate: Date;
+  endDate: Date;
   wakeTime: Date;
   hostId: number;
   duration: number;

--- a/frontend/src/apis/challengeServices.js
+++ b/frontend/src/apis/challengeServices.js
@@ -72,6 +72,16 @@ const checkMateAvailability = async ({ accessToken, email }) => {
   return await API.get(url, config);
 };
 
+const completeChallenge = async ({ accessToken, challengeId, userId }) => {
+  const url = `/challenge/complete/${challengeId}/${userId}`;
+  const config = {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  };
+
+  // post 요청이지만 body가 없는 경우 빈 객체를 전달해야 함!!!
+  return await API.post(url, {}, config);
+};
+
 const getCalendarInfo = async ({ accessToken, userId, month }) => {
   const url = `/challenge/calendar/${userId}/${month}`;
   const config = {
@@ -100,6 +110,7 @@ const getConnectionToken = async ({ accessToken, userData }) => {
 export const challengeServices = {
   getChallengeInfo,
   createChallenge,
+  completeChallenge,
   checkMateAvailability,
   getInvitationInfo,
   acceptInvitation,

--- a/frontend/src/pages/Main/cardComponents/ChallengeContent.js
+++ b/frontend/src/pages/Main/cardComponents/ChallengeContent.js
@@ -1,6 +1,10 @@
 import React, { useContext, useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { AccountContext, ChallengeContext } from '../../../contexts';
+import {
+  AccountContext,
+  UserContext,
+  ChallengeContext,
+} from '../../../contexts';
 
 // Import Swiper styles
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -13,6 +17,7 @@ import { LoadingWithText } from '../../../components';
 
 const ChallengeContent = () => {
   const { userId: myId } = useContext(AccountContext);
+  const { myData } = useContext(UserContext);
   const { challengeData } = useContext(ChallengeContext);
   const [isChallengeLoading, setIsChallengeLoading] = useState(true);
 
@@ -22,10 +27,7 @@ const ChallengeContent = () => {
     }
   }, [challengeData]);
 
-  const remainingDays = calculateRemainingDays(
-    challengeData?.startDate,
-    challengeData?.duration,
-  );
+  const remainingDays = calculateRemainingDays(challengeData?.endDate);
 
   const matesWithoutMe = challengeData?.mates?.filter(
     mate => mate?.userId !== myId,
@@ -34,70 +36,65 @@ const ChallengeContent = () => {
   const matesNames = matesWithoutMe?.map(mate => mate?.userName).join(', ');
 
   const sliderBox = [
-    <SlideContent $isSingleLine={true}>
+    <SlideContent $isSingleLine={true} key="slider-wake-up-time">
       매일 아침{' '}
       <HighlightText>
         {challengeData.wakeTime?.split(':')?.slice(0, 2)?.join(':')}
       </HighlightText>
       에 일어나요
     </SlideContent>,
-    <SlideContent $isSingleLine={matesWithoutMe?.length === 1}>
-      {' '}
-      <HighlightText>{matesNames}</HighlightText>
-      {' 과(와) 함께 하고 있어요'}
-    </SlideContent>,
-    <SlideContent $isSingleLine={true}>
+    matesWithoutMe?.length === 0 ? (
+      <SlideContent $isSingleLine={true} key="slider-challenge-members">
+        <HighlightText>{myData?.userName}</HighlightText>님 혼자서 도전 중이에요
+      </SlideContent>
+    ) : (
+      <SlideContent
+        $isSingleLine={matesWithoutMe?.length === 1}
+        key="slider-challenge-members"
+      >
+        <HighlightText>{matesNames}</HighlightText>
+        {' 과(와) 함께 하고 있어요'}
+      </SlideContent>
+    ),
+    <SlideContent $isSingleLine={true} key="slider-end-date">
       완료까지 <HighlightText>{remainingDays}일</HighlightText> 남았어요
     </SlideContent>,
   ];
 
-  function calculateRemainingDays(startDate, duration) {
-    // 시작일 객체 생성
-    var start = new Date(startDate);
+  function calculateRemainingDays(endDate) {
+    let end = new Date(endDate);
+    let currentDate = new Date();
 
-    // 종료일 객체 생성
-    var end = new Date(start);
-    end.setDate(end.getDate() + duration);
-
-    // 현재 날짜 객체 생성
-    var currentDate = new Date();
-
-    // 종료일과 현재 날짜 사이의 차이를 계산하여 일 수로 반환
-    var remainingDays = Math.ceil((end - currentDate) / (1000 * 60 * 60 * 24));
+    let remainingDays = Math.ceil((end - currentDate) / (1000 * 60 * 60 * 24));
 
     return remainingDays - 1;
   }
 
-  return (
-    <>
-      {isChallengeLoading ? (
-        <LoadingWrapper>
-          <LoadingWithText />
-        </LoadingWrapper>
-      ) : (
-        <Swiper
-          // autoplay={{ delay: 1000 }} //3초
-          // loop={true} //반복
-          spaceBetween={50}
-          // onSwiper={swiper => console.log(swiper)}
-          pagination={{
-            dynamicBullets: true,
-            bulletClass: 'swiper-pagination-bullet', // bullet의 클래스명
-          }}
-          modules={[Pagination]}
-          className="mySwiper"
-        >
-          {sliderBox.map((challenge, index) => (
-            <SwiperSlide key={index}>
-              <Wrapper>
-                <ChallengeTitle>진행 중 챌린지</ChallengeTitle>
-                {challenge}
-              </Wrapper>
-            </SwiperSlide>
-          ))}
-        </Swiper>
-      )}
-    </>
+  return isChallengeLoading ? (
+    <LoadingWrapper>
+      <LoadingWithText />
+    </LoadingWrapper>
+  ) : (
+    <Swiper
+      // autoplay={{ delay: 1000 }} //3초
+      // loop={true} //반복
+      spaceBetween={50}
+      pagination={{
+        dynamicBullets: true,
+        bulletClass: 'swiper-pagination-bullet', // bullet의 클래스명
+      }}
+      modules={[Pagination]}
+      className="mySwiper"
+    >
+      {sliderBox.map((challenge, index) => (
+        <SwiperSlide key={index}>
+          <Wrapper>
+            <ChallengeTitle>진행 중 챌린지</ChallengeTitle>
+            {challenge}
+          </Wrapper>
+        </SwiperSlide>
+      ))}
+    </Swiper>
   );
 };
 


### PR DESCRIPTION
## challenge 완료 여부 체크 api 연동

## #️⃣ Part

- [x] FE
- [x] BE

## 📝 작업 내용
- 챌린지의 완료 여부를 확인하고, 완료된 경우 필요한 작업을 진행하는 api를 연동함
  - main 화면 진입시, challenge의 endDate과 접속 시점의 대소를 비교하여, endDate이 지난 시간인 경우 해당 api를 호출
  - main 화면 진입시 마운트되는 ChallengeContext에서 해당 로직이 처리됨

- 추가로 챌린지 table의 endDate 컬럼 정보를 front에서 활용할 수 있도록, backend의 getChallengeInfo api의 반환값에 endDate추가함


