### PR TITLE
Fix: complete challenge 로직 수정

### DIFF
--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -481,9 +481,10 @@ export class ChallengesService {
       await this.redisCacheService.del(`challenge_${challengeId}`);
       await this.challengeRepository.save(challenge);
     } else {
-      throw new BadRequestException(
-        `Challenge with ID ${challengeId} is already completed.`,
-      );
+      // 늦게 들어온 사람의 경우 이미 completed 되어있지만, 개인 정보는 바꿔줘야 하므로 에러 발생하면 안 됨.
+      // throw new BadRequestException(
+      //   `Challenge with ID ${challengeId} is already completed.`,
+      // );
     }
     await this.userService.resetChallenge(userId); // 2.user 챌린지 정보를 -1로 변경
 


### PR DESCRIPTION
## complete challenge API 로직 수정

## #️⃣ Part

- [ ] FE
- [x] BE

## 📝 작업 내용
챌린지 참여자 중 누군가 먼저 challenge table의 completed를 true로 업데이트하더라도, 나머지 챌린지 참여자가 접속했을때 에러 없이 본인의 정보를 업데이트 할 수 있도록 변경