### PR TITLE
Modify: Offline page에서 online 상태 감지하여, main page로 자동 이동

### DIFF
--- a/frontend/src/components/OfflinePage.js
+++ b/frontend/src/components/OfflinePage.js
@@ -1,14 +1,34 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { LongBtn } from './';
 import * as S from '../styles/common';
 
 const OfflinePage = () => {
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleOnline = () => {
+      navigate('/main');
+    };
+
+    window.addEventListener('online', handleOnline);
+
+    if (navigator.onLine) {
+      navigate('/main');
+    }
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+    };
+  }, [navigate]);
+
   return (
     <S.PageWrapper>
       인터넷이 연결되어 있지 않습니다. 네트워크를 확인해주세요.
-      <LongBtn btnName="홈으로" onClickHandler={() => navigate('/main')} />
+      <LongBtn
+        btnName="새로고침"
+        onClickHandler={() => window.location.reload()}
+      />
     </S.PageWrapper>
   );
 };

--- a/frontend/src/hooks/useFetch.js
+++ b/frontend/src/hooks/useFetch.js
@@ -1,6 +1,8 @@
 import { useNavigate } from 'react-router-dom';
+
 const useFetch = () => {
   const navigate = useNavigate();
+
   const fetchData = async callback => {
     const callResponse = {
       isLoading: true,
@@ -8,6 +10,12 @@ const useFetch = () => {
       data: null,
       error: null,
     };
+
+    if (!navigator.onLine) {
+      navigate('/offline');
+      return;
+    }
+
     try {
       const response = await callback();
 
@@ -17,6 +25,7 @@ const useFetch = () => {
     } catch (error) {
       if (!navigator.onLine) {
         navigate('/offline');
+        return;
       } else {
         const message =
           error.response?.data?.message ||


### PR DESCRIPTION
## Offline page에서 online 상태 감지하여, main page로 자동 이동

## #️⃣ Part

- [x] FE
- [ ] BE

## 📝 작업 내용
- 문제: 기존 로직은 사용자가 offline 페이지에 머물러있는 동안 네트워크가 온라인으로 바뀌어도, 변화를 감지하지 못하여, 사용자가 home으로 이동하는 버튼을 누르지 않는이상 계속 offline에 머물러 있어야 했음.
- 보완 1 : offline 페이지 컴포넌트 내부에 온라인 상태 감지 listener를 추가하여, 변화가 있을 경우 자동으로 main page로 이동할 수 있도록 처리
- 보완 2: 기존의 home으로 이동 버튼은 사용자에게 네트워크 상태 확인을 재시도 해보는 느낌을 주지 못해서, 새로고침 버튼으로 바꿈

+ useFetch hook에서 api 호출을 할때도, try 전에 바로 offline 상태 확인하여 이동시키는 로직 추가함