### PR TITLE
Fix: Back/createChallenge - 챌린지 생성 경험있는 유저의 새로운 챌린지 생성시의 문제 해결

### DIFF
--- a/backend/src/challenges/challenges.entity.ts
+++ b/backend/src/challenges/challenges.entity.ts
@@ -8,11 +8,14 @@ import {
   ManyToOne,
   OneToMany,
   JoinColumn,
-  Unique,
+  Index,
 } from 'typeorm';
 
 @Entity()
-@Unique(['hostId']) // hostId에 대해 고유 제약 조건 설정.
+@Index('UQ_host_active_challenge', ['hostId'], {
+  unique: true,
+  where: 'completed = false',
+}) // complete된 챌린지는 hostId가 중복될 수 있으나, 아닌 경우는 중복이 불가하도록 unique 제약조건 추가
 export class Challenges {
   @PrimaryGeneratedColumn()
   _id: number;

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -50,6 +50,19 @@ export class ChallengesService {
   }
 
   async createChallenge(challenge: CreateChallengeDto): Promise<Challenges> {
+    const user = await this.userService.findOneByID(challenge.hostId);
+
+    if (!user) {
+      throw new NotFoundException(`User with ID ${challenge.hostId} not found`);
+    }
+
+    // challengeId가 -1이 아닌 경우 새로운 챌린지 생성 불가
+    if (user.challengeId !== -1) {
+      throw new BadRequestException(
+        'User is not eligible to create a new challenge. Please complete the existing challenge first.',
+      );
+    }
+
     this.validateStartAndWakeTime(challenge.startDate, challenge.wakeTime);
     this.validateDuration(challenge.duration);
 

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -217,6 +217,7 @@ export class ChallengesService {
     }
     return null;
   }
+
   async sendInvitation(challengeId: number, email: string): Promise<void> {
     console.log('sendInvitation', email);
     const user = await this.userRepository.findOne({
@@ -485,8 +486,7 @@ export class ChallengesService {
         `Challenge with ID ${challengeId} is already completed.`,
       );
     }
-    await this.userService.resetChallenge(userId); // 2.user 챌린지 정보를 -1로 변경
-
+    await this.userService.resetChallenge(userId); // 2.user 챌린지 정보 초기화 (challengeId = -1, openviduToekn = null )
     // 3. 메달처리
     // 기간별로 90%이상 80점 이상 달성시 메달 획득 금 100 은 30 동 7
     const qualifiedDaysCount = await this.attendanceRepository.count({

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -342,6 +342,7 @@ export class UserService {
       throw new NotFoundException('User not found');
     }
     user.challengeId = -1;
+    user.openviduToken = null;
     await this.redisService.del(`userInfo:${userId}`);
     await this.userRepository.save(user);
   }
@@ -365,6 +366,7 @@ export class UserService {
     await this.redisService.del(`userInfo:${userId}`);
     return await this.userRepository.save(user);
   }
+
   decideMedalType(duration: number): 'gold' | 'silver' | 'bronze' {
     if (duration === 100) {
       return 'gold';
@@ -409,9 +411,8 @@ export class UserService {
         }
       }
 
-      // 삭제될 사용자는 챌린지에서 빠짐
-      user.challengeId = -1;
-      await this.userRepository.save(user);
+      // 삭제될 사용자의 챌린지 정보 초기화
+      await this.resetChallenge(userId);
     }
 
     // 챌린지 정보 캐시 삭제


### PR DESCRIPTION
## createChallenge API 로직 수정
- 챌린지 생성 경험있는 유저의 새로운 챌린지 생성시의 문제 해결

## #️⃣ Part

- [ ] FE
- [x] BE

## 📝 작업 내용
- 상황
  - 기존에 challenge를 생성하였고, 해당 challenge가 만료된 host가 새로운 challenge를 생성하려고 할때, DB측에서 `error: duplicate key value violates unique constraint "UQ_*****"` 에러가 발생함.

- 원인
  - 우리 DB의 Challenge table이 hostId를 기준으로 unique제약 조건이 존재했음
  - 즉, 동일한 host가 challenge를 새로 생성할 수 없는 상황이었음
 
- 해결
  - Challenge가 completed false인 경우, 즉 아직 챌린지가 진행중인 경우에만 새로 생성할 수 없도록 제약조건을 걸음
  - === hostId & completed의 복합 유니크 조건

- 구현
  - DB에서 이전 규칙 제거 및 새로운 규칙 추가
  - 기존 createChallenge controller 및 service 로직 수정
 