### PR TITLE
Modify: 챌린지 시작일자가 한참 남은 경우 UI 수정

### DIFF
--- a/frontend/src/contexts/GameContext.js
+++ b/frontend/src/contexts/GameContext.js
@@ -38,6 +38,7 @@ const GameContextProvider = ({ children }) => {
   const { challengeData } = useContext(ChallengeContext);
   const { checkTime } = useCheckTime();
   const { remainingTime, isTooLate, isTooEarly } = checkTime(
+    challengeData?.startDate,
     challengeData?.wakeTime,
   );
 

--- a/frontend/src/hooks/useCheckTime.js
+++ b/frontend/src/hooks/useCheckTime.js
@@ -1,9 +1,32 @@
 const useCheckTime = () => {
-  const checkTime = wakeTime => {
-    if (wakeTime === undefined)
-      return { isTooEarly: false, isTooLate: false, remainingTime: 0 };
+  const checkTime = (startDate, wakeTime) => {
+    const result = {
+      isTooEarly: false,
+      isTooLate: false,
+      remainingTime: -1,
+      diffDays: null,
+    };
+    if (startDate === undefined || wakeTime === undefined) return result;
 
     const now = new Date();
+    const startDateDate = new Date(startDate);
+
+    const nowDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const startDateNormalized = new Date(
+      startDateDate.getFullYear(),
+      startDateDate.getMonth(),
+      startDateDate.getDate(),
+    );
+
+    // 현재 날짜가 시작일보다 이전인 경우 날짜만 비교하여 return
+    if (nowDate < startDateNormalized) {
+      const diffTime = startDateDate.getTime() - now.getTime();
+      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+      return { ...result, diffDays };
+    }
+
+    // 현재 날짜가 시작일 당일이거나 이후인 경우, 시간을 비교
     const wakeTimeDate = new Date(
       now.getFullYear(),
       now.getMonth(),
@@ -33,7 +56,11 @@ const useCheckTime = () => {
 
     const remainingTime = wakeTimeDate.getTime() - now.getTime();
 
-    return { isTooEarly, isTooLate, remainingTime };
+    result.isTooEarly = isTooEarly;
+    result.isTooLate = isTooLate;
+    result.remainingTime = remainingTime;
+
+    return result;
   };
 
   return { checkTime };

--- a/frontend/src/pages/InGame/InGame.js
+++ b/frontend/src/pages/InGame/InGame.js
@@ -38,7 +38,10 @@ const InGame = () => {
   const { userId: myId } = useContext(AccountContext);
   const { challengeData } = useContext(ChallengeContext);
   const { checkTime } = useCheckTime();
-  const { isTooLate, isTooEarly } = checkTime(challengeData?.wakeTime);
+  const { isTooLate, isTooEarly } = checkTime(
+    challengeData?.startDate,
+    challengeData?.wakeTime,
+  );
   const { inGameMode, isEnteredTimeSent, sendEnteredTime } =
     useContext(GameContext);
   const { myStream, myVideoRef } = useContext(OpenViduContext);

--- a/frontend/src/pages/InGame/components/Nav/Timer.js
+++ b/frontend/src/pages/InGame/components/Nav/Timer.js
@@ -7,7 +7,10 @@ import styled from 'styled-components';
 const Timer = () => {
   const { challengeData } = useContext(ChallengeContext);
   const { checkTime } = useCheckTime();
-  const { remainingTime } = checkTime(challengeData?.wakeTime);
+  const { remainingTime } = checkTime(
+    challengeData?.startDate,
+    challengeData?.wakeTime,
+  );
 
   const CountDownUI = props => {
     const { formatted, milliseconds, completed } = props;

--- a/frontend/src/pages/Main/Main.js
+++ b/frontend/src/pages/Main/Main.js
@@ -1,16 +1,13 @@
 import React, { useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { UserContext, ChallengeContext, AccountContext } from '../../contexts';
-import useCheckTime from '../../hooks/useCheckTime';
-import BottomFixContent from './cardComponents/BottomFixContent';
 import { NavBar, OutlineBox, LoadingWithText } from '../../components';
 import {
   StreakContent,
   InvitationsContent,
-  CreateContent,
   ChallengeContent,
-  EnterContent,
 } from './cardComponents';
+import BottomFixContent from './cardComponents/BottomFixContent';
 import { CARD_TYPES, CARD_STYLES } from './DATA';
 
 import styled from 'styled-components';
@@ -21,17 +18,14 @@ const Main = () => {
 
   const { accessToken, userId } = useContext(AccountContext);
   const { challengeId, getMyData } = useContext(UserContext);
-  const { challengeData, isAttended } = useContext(ChallengeContext);
-  const { checkTime } = useCheckTime();
+  const { challengeData } = useContext(ChallengeContext);
 
   const hasChallenge = Number(challengeId) !== -1;
 
   const CARD_CONTENTS = {
     streak: <StreakContent />,
     invitations: <InvitationsContent />,
-    create: <CreateContent />,
     challenge: <ChallengeContent challenges={challengeData} />,
-    enter: <EnterContent />,
   };
 
   const CARD_ON_CLICK_HANDLERS = {
@@ -40,21 +34,7 @@ const Main = () => {
       // 초대받은 challenge 존재 여부에 따라 분기처리
       navigate('/joinChallenge');
     },
-    create: () => navigate('/createChallenge'),
     challenge: null,
-    enter: () => {
-      const { isTooEarly, isTooLate } = checkTime(challengeData?.wakeTime);
-
-      if (isTooEarly) {
-        alert('너무 일찍 오셨습니다. 10분 전부터 입장 가능합니다.');
-      } else if (isTooLate && !isAttended) {
-        alert('챌린지 참여 시간이 지났습니다. 내일 다시 참여해주세요.');
-      } else if (isTooLate && isAttended) {
-        alert('멋져요! 오늘의 미라클 모닝 성공! 내일 또 만나요');
-      } else {
-        navigate(`/startMorning`);
-      }
-    },
   };
 
   useEffect(() => {
@@ -85,7 +65,7 @@ const Main = () => {
             ),
           )}
         </CardsWrapper>
-        <BottomFixContent onClickHandler={CARD_ON_CLICK_HANDLERS} />
+        <BottomFixContent />
       </S.PageWrapper>
     </>
   );

--- a/frontend/src/pages/Main/cardComponents/BottomFixContent.js
+++ b/frontend/src/pages/Main/cardComponents/BottomFixContent.js
@@ -1,26 +1,38 @@
 import React, { useState, useEffect, useContext } from 'react';
-import styled from 'styled-components';
+import { ChallengeContext, UserContext } from '../../../contexts';
+import useCheckTime from '../../../hooks/useCheckTime';
 import EnterContent from './EnterContent';
 import CreateContent from './CreateContent';
 import { Icon } from '../../../components';
-// import { Timer } from '../../InGame/components/Nav';
 
 import { LoadingWithText } from '../../../components';
-import { ChallengeContext, UserContext } from '../../../contexts';
+import styled from 'styled-components';
 
-const BottomFixContent = ({ onClickHandler }) => {
-  const challengeData = useContext(ChallengeContext);
-  const challengeId = useContext(UserContext).challengeId;
-  const wakeTime = challengeData?.challengeData?.wakeTime;
+const BottomFixContent = () => {
+  const { checkTime } = useCheckTime();
+  const { challengeId } = useContext(UserContext);
+  const { challengeData } = useContext(ChallengeContext);
+
+  const [wakeTime, setWakeTime] = useState(challengeData?.wakeTime);
+  const [diffDays, setDiffDays] = useState(null);
   const [timeLeft, setTimeLeft] = useState(null);
   const [isChallengeIdLoading, setIsChallengeIdLoading] = useState(true);
 
   useEffect(() => {
-    // challengeData가 로드된 후에 로딩 상태를 해제
-    if (challengeId !== null) {
-      setIsChallengeIdLoading(false);
-    }
-  }, [challengeData, challengeId]);
+    if (!challengeId) return;
+    setIsChallengeIdLoading(false);
+  }, [challengeId]);
+
+  useEffect(() => {
+    if (!challengeData?.wakeTime) return;
+    setWakeTime(challengeData.wakeTime);
+
+    const { diffDays } = checkTime(
+      challengeData?.startDate,
+      challengeData?.wakeTime,
+    );
+    setDiffDays(diffDays);
+  }, [challengeData]);
 
   useEffect(() => {
     if (!wakeTime) return; // wakeTime이 없으면 실행하지 않음
@@ -76,25 +88,32 @@ const BottomFixContent = ({ onClickHandler }) => {
             {/* <Icon icon={'smile'} iconStyle={iconStyleSample} /> */}
           </IconWrapper>
 
-          <CreateContent onClickHandler={onClickHandler.create} />
+          <CreateContent />
         </>
       ) : (
         <>
           <TimeDisplay>
             <TimeTitleWrapper>
-              <Icon icon={'timer'} iconStyle={iconStyleSample} />
+              <Icon icon="timer" iconStyle={iconStyleSample} />
               <TimeTitle>기상까지 남은 시간</TimeTitle>
             </TimeTitleWrapper>
             <SeperateLine />
             <Timer>
-              <TimerText>{timeLeft?.split(':')[0]}</TimerText>
-              {timeLeft && <TimerText2>:</TimerText2>}
-              <TimerText>{timeLeft?.split(':')[1]}</TimerText>
-              {timeLeft && <TimerText2>:</TimerText2>}
-              <TimerText>{timeLeft?.split(':')[2]}</TimerText>
+              {diffDays ? (
+                <TimerText>D-{diffDays}일 </TimerText>
+              ) : (
+                <>
+                  {' '}
+                  <TimerText>{timeLeft?.split(':')[0]}</TimerText>
+                  {timeLeft && <TimerText2>:</TimerText2>}
+                  <TimerText>{timeLeft?.split(':')[1]}</TimerText>
+                  {timeLeft && <TimerText2>:</TimerText2>}
+                  <TimerText>{timeLeft?.split(':')[2]}</TimerText>
+                </>
+              )}
             </Timer>
           </TimeDisplay>
-          <EnterContent onClickHandler={onClickHandler.enter} />
+          <EnterContent />
         </>
       )}
     </Wrapper>

--- a/frontend/src/pages/Main/cardComponents/CreateContent.js
+++ b/frontend/src/pages/Main/cardComponents/CreateContent.js
@@ -1,26 +1,36 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-const CreateContent = ({ onClickHandler }) => {
-  return <Wrapper onClick={onClickHandler}>챌린지 생성하기</Wrapper>;
+const CreateContent = () => {
+  const navigate = useNavigate();
+  const moveToCreateChallenge = () => {
+    navigate('/createChallenge');
+  };
+  return <Wrapper onClick={moveToCreateChallenge}>챌린지 생성하기</Wrapper>;
 };
 
 export default CreateContent;
 
-const Wrapper = styled.div`
+const Wrapper = styled.button`
   ${({ theme }) => theme.flex.center};
   ${({ theme }) => theme.fonts.JuaSmall};
+
+  width: 300px;
+  height: 56px;
 
   padding: 10px 10px 6px 10px;
 
   border-radius: ${({ theme }) => theme.radius.medium};
 
+  border: 1px solid var(--Gradient-Emerald, #836fff);
   background: rgba(13, 10, 45, 0.75);
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(2px);
-  border: 1px solid var(--Gradient-Emerald, #836fff);
 
-  width: 300px;
-  height: 56px;
+  color: white;
+
   z-index: 2000;
+
+  cursor: pointer;
 `;

--- a/frontend/src/pages/Main/cardComponents/EnterContent.js
+++ b/frontend/src/pages/Main/cardComponents/EnterContent.js
@@ -1,26 +1,78 @@
-import React from 'react';
+import React, { useContext, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChallengeContext } from '../../../contexts';
+import useCheckTime from '../../../hooks/useCheckTime';
 import styled from 'styled-components';
 
-const EnterContent = ({ onClickHandler }) => {
-  return <Wrapper onClick={onClickHandler}>챌린지 참여하기</Wrapper>;
+const MESSAGES = {
+  NOT_STARTED:
+    '챌린지가 아직 시작되지 않았습니다. 당일 10분 전부터 입장 가능합니다.',
+  TOO_EARLY: '너무 일찍 오셨습니다. 10분 전부터 입장 가능합니다.',
+  TOO_LATE: '챌린지 참여 시간이 지났습니다. 내일 다시 참여해주세요.',
+  SUCCESS: '멋져요! 오늘의 미라클 모닝 성공! 내일 또 만나요',
+};
+
+const EnterContent = () => {
+  const navigate = useNavigate();
+  const { checkTime } = useCheckTime();
+  const { challengeData, isAttended } = useContext(ChallengeContext);
+  const [checkTimeResult, setCheckTimeResult] = useState(null);
+
+  useEffect(() => {
+    if (!challengeData?.wakeTime) return;
+
+    const { isTooEarly, isTooLate, diffDays } = checkTime(
+      challengeData?.startDate,
+      challengeData?.wakeTime,
+    );
+    setCheckTimeResult({ isTooEarly, isTooLate, diffDays });
+  }, [challengeData]);
+
+  const enterHandler = () => {
+    if (!checkTimeResult) return;
+
+    const { isTooEarly, isTooLate, diffDays } = checkTimeResult;
+    if (diffDays > 0) {
+      alert(MESSAGES.NOT_STARTED);
+    } else if (isTooEarly) {
+      alert(MESSAGES.TOO_EARLY);
+    } else if (isTooLate && !isAttended) {
+      alert(MESSAGES.TOO_LATE);
+    } else if (isTooLate && isAttended) {
+      alert(MESSAGES.SUCCESS);
+    } else {
+      navigate(`/startMorning`);
+    }
+  };
+
+  return (
+    <Wrapper $isLoading={!checkTimeResult} onClick={enterHandler}>
+      챌린지 참여하기
+    </Wrapper>
+  );
 };
 
 export default EnterContent;
 
-const Wrapper = styled.div`
+const Wrapper = styled.button`
   ${({ theme }) => theme.flex.center};
   ${({ theme }) => theme.fonts.JuaSmall};
+
+  width: 300px;
+  height: 56px;
 
   padding: 10px 10px 6px 10px;
 
   border-radius: ${({ theme }) => theme.radius.medium};
 
+  border: 1px solid var(--Gradient-Emerald, #836fff);
   background: rgba(13, 10, 45, 0.75);
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(2px);
-  border: 1px solid var(--Gradient-Emerald, #836fff);
 
-  width: 300px;
-  height: 56px;
+  color: white;
+
   z-index: 1000;
+
+  cursor: ${({ $isLoading }) => ($isLoading ? 'not-allowed' : 'pointer')};
 `;


### PR DESCRIPTION
## Modify: 챌린지 시작일자가 한참 남은 경우 UI 수정

## #️⃣ Part

- [x] FE
- [ ] BE

## 📝 작업 내용
- 문제 상황
  - 챌린지 생성은 하였으나, 시작일자가 하루이상 남은 경우, 언제 시작하는지 알 수 없으며, 그저 10분 전에만 참여할 수 있다는 alert만 뜨던 상황
- 해결
  - 유저의 접속일자로부터 챌린지 시작일자가 1일 이상 남은 경우, Main 화면의 시간초를 보여주는 곳에 D-day를 보여줌
- 구현 방법
  - 기존의 useCheckTime hook에 남은 일자 계산 로직 추가
  - Main 페이지의 BottomFixContent 컴포넌트에 수정된 useCheckTime 사용할 수 있도록 분기처리