### PR TITLE
feat : ELB 헬스체크 logging 무시

### DIFF
--- a/backend/src/challenges/challenges.controller.ts
+++ b/backend/src/challenges/challenges.controller.ts
@@ -34,12 +34,9 @@ export class ChallengesController {
   async getChallengeInfo(
     @Query('challengeId') challengeId: number,
   ): Promise<ChallengeResponseDto> {
-    const challenge = await this.challengeService.getChallengeInfo(challengeId);
-    if (!challenge) {
-      throw new NotFoundException(`Challenge with ID ${challengeId} not found`);
-    }
-    return challenge;
+    return await this.challengeService.getChallengeInfo(challengeId);
   }
+
   @Post('create')
   async createChallenge(@Body() createChallengeDto: CreateChallengeDto) {
     console.log('create');

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -273,7 +273,7 @@ export class ChallengesService {
     });
 
     if (!challenge) {
-      return null; // 챌린지가 없으면 null 반환
+      throw new NotFoundException(`Challenge with ID ${challengeId} not found`);
     }
 
     // 해당 챌린지 ID를 가진 모든 사용자 검색

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -72,10 +72,12 @@ export class ChallengesService {
     this.validateStartAndWakeTime(challenge.startDate, challenge.wakeTime);
     this.validateDuration(challenge.duration);
 
-    const editChall = await this.challengeRepository.findOne({
-      where: { _id: challenge.challengeId },
-    });
-
+    let editChall = await this.redisCheckChallenge(challenge.challengeId);
+    if (!editChall) {
+      editChall = await this.challengeRepository.findOne({
+        where: { _id: challenge.challengeId },
+      });
+    }
     if (!editChall) {
       throw new NotFoundException(
         `Challenge with ID ${challenge.challengeId} not found`,

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -449,9 +449,14 @@ export class ChallengesService {
   }
 
   async setWakeTime(setChallengeWakeTimeDto): Promise<void> {
-    const challengeValue = await this.challengeRepository.findOne({
-      where: { _id: setChallengeWakeTimeDto.challengeId },
-    });
+    let challengeValue = await this.redisCheckChallenge(
+      setChallengeWakeTimeDto.challengeId,
+    );
+    if (!challengeValue) {
+      challengeValue = await this.challengeRepository.findOne({
+        where: { _id: setChallengeWakeTimeDto.challengeId },
+      });
+    }
     if (!challengeValue) {
       throw new NotFoundException(
         `Challenge with ID ${setChallengeWakeTimeDto.challengeId} not found`,

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -477,9 +477,12 @@ export class ChallengesService {
     challengeId: number,
     userId: number,
   ): Promise<boolean> {
-    const challenge = await this.challengeRepository.findOne({
-      where: { _id: challengeId },
-    });
+    let challenge = await this.redisCheckChallenge(challengeId);
+    if (!challenge) {
+      challenge = await this.challengeRepository.findOne({
+        where: { _id: challengeId },
+      });
+    }
     if (!challenge) {
       throw new NotFoundException(`Challenge with ID ${challengeId} not found`);
     }

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -295,6 +295,9 @@ export class ChallengesService {
       hostId: challenge.hostId,
       wakeTime: challenge.wakeTime,
       duration: challenge.duration,
+      endDate: challenge.endDate,
+      completed: challenge.completed,
+      deleted: challenge.deleted,
       mates: participantDtos,
     };
 
@@ -306,6 +309,7 @@ export class ChallengesService {
         parseInt(process.env.REDIS_CHALLENGE_EXP),
       ); // 10분 TTL
     }
+    console.log(challengeResponse);
 
     return challengeResponse;
   }

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -303,7 +303,6 @@ export class ChallengesService {
       hostId: challenge.hostId,
       wakeTime: challenge.wakeTime,
       duration: challenge.duration,
-      endDate: challenge.endDate,
       completed: challenge.completed,
       deleted: challenge.deleted,
       mates: participantDtos,

--- a/backend/src/challenges/dto/challengeResponse.dto.ts
+++ b/backend/src/challenges/dto/challengeResponse.dto.ts
@@ -4,6 +4,9 @@ export class ChallengeResponseDto {
   wakeTime: Date;
   hostId: number;
   duration: number;
+  endDate: Date;
+  completed: boolean;
+  deleted: boolean;
   mates: ParticipantDto[];
 }
 export class ParticipantDto {

--- a/backend/src/challenges/dto/challengeResponse.dto.ts
+++ b/backend/src/challenges/dto/challengeResponse.dto.ts
@@ -5,7 +5,6 @@ export class ChallengeResponseDto {
   wakeTime: Date;
   hostId: number;
   duration: number;
-  endDate: Date;
   completed: boolean;
   deleted: boolean;
   mates: ParticipantDto[];

--- a/backend/src/common/Interceptors/logging.interceptor.ts
+++ b/backend/src/common/Interceptors/logging.interceptor.ts
@@ -15,6 +15,11 @@ export class LoggingInterceptor implements NestInterceptor {
     const request = context.switchToHttp().getRequest();
     const { method, url, headers, body } = request;
 
+    // 헬스체크 요청 무시
+    if (headers['user-agent']?.includes('ELB-HealthChecker')) {
+      return next.handle();
+    }
+
     // 요청 정보 로깅
     winstonLogger.log(`Request Method: ${method} URL: ${url}`, {
       headers: filterSensitiveInfo(headers),


### PR DESCRIPTION
## #️⃣ Part

- [ ] FE
- [x] BE

## 📝 작업 내용
AWS에서 사용하고 있는 로드밸런서에서는 우리 서버로 약 2초? 간 헬스체크를 위해 url 요청을 보내고 있는데 서버에서는 요청을 보낼때 마다 logging을 하고 있어 로그메세지의 양이 방대해짐

url 요청시 interceptor에서 user-agent가 'ELB-HealthChecker' 인경우 로깅을 무시함
