### PR TITLE
Fix: LoadModel.js - 현재 접속자 수 체크 로직(allReady) 수정

### DIFF
--- a/frontend/src/pages/InGame/LoadModel/LoadModel.js
+++ b/frontend/src/pages/InGame/LoadModel/LoadModel.js
@@ -157,7 +157,7 @@ const LoadModel = () => {
 
       // 모든 현재 접속자가 ready 상태인지 확인
       const allReady =
-        currentMates.length > 0 &&
+        currentMates.length >= 0 &&
         currentMates.every(mate => matesReadyStatus?.[mate.userId]?.ready);
 
       // 프로그레스바 업데이트


### PR DESCRIPTION
## #️⃣ Part

- [x] FE
- [ ] BE

## 📝 작업 내용

2인의 챌린지에서 1명만 접속한 상황,
`LoadModel.js`의 `allReady`를 0을 포함하는 것으로
"친구를 기다리는 중입니다" 에서 게임으로 넘어가지 않는 문제 해결