### PR TITLE
Backend/refactor

### DIFF
--- a/backend/src/challenges/challenges.controller.ts
+++ b/backend/src/challenges/challenges.controller.ts
@@ -90,9 +90,11 @@ export class ChallengesController {
 
   @Post('edit')
   async editChallenge(@Body() editChallengeDto: EditChallengeDto) {
-    const challenge =
+    const challengeResult =
       await this.challengeService.editChallenge(editChallengeDto);
-    return challenge;
+    if (challengeResult.affected !== 0) {
+      return { message: '챌린지 수정 성공', status: 200 };
+    }
   }
 
   @Post('delete/:challengeId/:userId') // 챌린지 생성하고 시작하지 않고 삭제하는 경우

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -133,7 +133,8 @@ export class ChallengesService {
         '해당 챌린지는 이미 시작되어 삭제할 수 없습니다.',
       );
     }
-
+    const cacheKey = `challenge_${challenge._id}`;
+    await this.redisCacheService.del(cacheKey);
     // 3. Host 여부에 따라 분기 처리
     if (challenge.hostId === userId) {
       // Host 인 경우 Challenge 삭제 및 관련 사용자 초기화

--- a/backend/src/common/Interceptors/logging.interceptor.ts
+++ b/backend/src/common/Interceptors/logging.interceptor.ts
@@ -15,13 +15,20 @@ export class LoggingInterceptor implements NestInterceptor {
     const request = context.switchToHttp().getRequest();
     const { method, url, headers, body } = request;
 
+    const clientIp = headers['x-forwarded-for'] || request.ip;
+    const userAgent = headers['user-agent'];
+
     // 헬스체크 요청 무시
-    if (headers['user-agent']?.includes('ELB-HealthChecker')) {
+    if (userAgent?.includes('ELB-HealthChecker')) {
       return next.handle();
     }
 
     // 요청 정보 로깅
-    winstonLogger.log(`Request Method: ${method} URL: ${url}`, {
+    winstonLogger.log('Request Info', {
+      method,
+      url,
+      clientIp,
+      userAgent,
       headers: filterSensitiveInfo(headers),
       body: filterSensitiveInfo(body),
     });


### PR DESCRIPTION
## #️⃣ Part

- [ ] FE
- [x] BE


## 📝 작업 내용
1. delete시 challenge탈퇴 유저가 리스트에 남아있어 cache 삭제 진행 
2. edit 시 cache에 값이 있는경우 cache의 challenge값을 새로운 entity로 인식하여 insert작업수행 -> 중복된 키값을 insert 함으로 고유키값 제약 발생 
    1. update는 굳이 data 값을 조회할 필요가 없다고 판단 cache체크및 db 조회 삭제
    2. 예외처리 한가지로 통일하였는데 요청log에 찍히니까 권한 에러랑 리소스 존재 유무 에러 구분안함
    3. edit시 변환된 challenge 값 반환하였는데 코드와 메세지 반환으로 변경 ( notion도 수정함)
3. 로깅시 정부 추가
    1. 요청 정보 로깅시 User-Agent및 IP 추가
    2. 에러로깅시 Request 정보 추가 및 UserAgent, IP정보 추가
    3. 에러 로그메세지 구조화