### PR TITLE
feat: challengeGiveUP시 캐시데이터를 새로운 객체로 인식하는 문제 해결

### DIFF
--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -160,12 +160,11 @@ export class ChallengesService {
   }
 
   async challengeGiveUp(challengeId: number, userId: number): Promise<void> {
-    let challenge = await this.redisCheckChallenge(challengeId);
-    if (challenge == null) {
-      challenge = await this.challengeRepository.findOne({
-        where: { _id: challengeId },
-      });
-    }
+    // 캐시 받아 올시 save시 새로운 객체로 인식하여 중복키 문제 발생
+    const challenge = await this.challengeRepository.findOne({
+      where: { _id: challengeId },
+    });
+
     if (!challenge) {
       throw new NotFoundException(`해당 챌린지를 찾을 수 없습니다.`);
     }


### PR DESCRIPTION
## #️⃣ Part

- [ ] FE
- [x] BE


## 📝 작업 내용
챌린지 캐시 데이터를 받아온다음 그 객체로 챌린지 정보 수정시 새로운 객체로 인식하여 중복키 문제 발생 -> 캐시 데이터 조회 안하는걸로 수정 ( 임시) 