### PR TITLE
feat: 챌린지 초대 분리

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -101,7 +101,7 @@ export class AuthService {
     });
   }
   async authNumcheck(email: string, data: string) {
-    const serverNum = await this.redisService.get(email);
+    const serverNum = (await this.redisService.get(email)).trim();
     if (serverNum === data) {
       return true;
     } else {

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -242,6 +242,15 @@ export class ChallengesService {
     const currentParticipants = await this.userRepository.count({
       where: { challengeId: challengeId },
     });
+    const challenge = await this.challengeRepository.findOne({
+      where: { _id: challengeId },
+    });
+    if (!challenge) {
+      throw new NotFoundException('해당 챌린지가 존재하지 않습니다.');
+    }
+    if (this.validateChallengeDate(responseDatedate, challenge)) {
+      throw new BadRequestException('해당 챌린지가 진행 중 입니다.');
+    }
     if (currentParticipants >= 4) {
       //await this.invitaionRepository.delete({ challengeId, guestId });
       throw new BadRequestException('챌린지 참가 인원이 초과되었습니다.');
@@ -268,6 +277,9 @@ export class ChallengesService {
     } catch (e) {
       throw new Error('초대 수락을 처리하는 중에 오류가 발생했습니다.');
     }
+  }
+  async deleteInvitation(invitation: AcceptInvitationDto) {
+    await this.invitationService.deleteInvitation(invitation);
   }
 
   async getChallengeInfo(

--- a/backend/src/challenges/dto/createChallenge.dto.ts
+++ b/backend/src/challenges/dto/createChallenge.dto.ts
@@ -34,7 +34,4 @@ export class CreateChallengeDto {
   @Type(() => Date)
   @IsDate()
   wakeTime: Date; // 기상 시간, 'time' 타입은 JavaScript에서 Date 타입으로 처리
-
-  @IsArray()
-  mates: string; // JSON 타입 데이터, 구체적인 구조는 클라이언트와 서버 간에 정의 필요
 }

--- a/backend/src/challenges/dto/createChallenge.dto.ts
+++ b/backend/src/challenges/dto/createChallenge.dto.ts
@@ -1,12 +1,4 @@
-import {
-  IsEnum,
-  IsJSON,
-  IsNotEmpty,
-  IsString,
-  IsDate,
-  IsNumber,
-  IsArray,
-} from 'class-validator';
+import { IsEnum, IsNotEmpty, IsDate, IsNumber, IsArray } from 'class-validator';
 import { Type } from 'class-transformer';
 
 // 적절한 enum 타입 정의, 예시로 몇 가지 값을 추가함
@@ -34,4 +26,7 @@ export class CreateChallengeDto {
   @Type(() => Date)
   @IsDate()
   wakeTime: Date; // 기상 시간, 'time' 타입은 JavaScript에서 Date 타입으로 처리
+
+  @IsArray()
+  mates: string; // JSON 타입 데이터, 구체적인 구조는 클라이언트와 서버 간에 정의 필요
 }

--- a/backend/src/challenges/dto/sendInvitationDto.ts
+++ b/backend/src/challenges/dto/sendInvitationDto.ts
@@ -1,11 +1,4 @@
-import { IsNotEmpty, IsDate, IsNumber, IsEmail } from 'class-validator';
-
-// 적절한 enum 타입 정의, 예시로 몇 가지 값을 추가함
-export enum Duration {
-  ONE_WEEK = 7,
-  ONE_MONTH = 30,
-  THREE_MONTHS = 100,
-}
+import { IsNotEmpty, IsNumber, IsEmail } from 'class-validator';
 
 export class SendInvitationDto {
   @IsNotEmpty()

--- a/backend/src/challenges/dto/sendInvitationDto.ts
+++ b/backend/src/challenges/dto/sendInvitationDto.ts
@@ -1,0 +1,18 @@
+import { IsNotEmpty, IsDate, IsNumber, IsEmail } from 'class-validator';
+
+// 적절한 enum 타입 정의, 예시로 몇 가지 값을 추가함
+export enum Duration {
+  ONE_WEEK = 7,
+  ONE_MONTH = 30,
+  THREE_MONTHS = 100,
+}
+
+export class SendInvitationDto {
+  @IsNotEmpty()
+  @IsNumber()
+  challengeId: number; // challengeId
+
+  @IsNotEmpty()
+  @IsEmail()
+  mateEmail: string;
+}

--- a/backend/src/invitations/invitations.service.ts
+++ b/backend/src/invitations/invitations.service.ts
@@ -3,6 +3,7 @@ import { Invitations } from './invitations.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import RedisCacheService from 'src/redis-cache/redis-cache.service';
+import { AcceptInvitationDto } from '../challenges/dto/acceptInvitaion.dto';
 
 @Injectable()
 export class InvitationsService {
@@ -22,5 +23,10 @@ export class InvitationsService {
     newInvitation.sendDate = new Date();
     newInvitation.responseDate = null;
     return await this.invitationRepository.save(newInvitation);
+  }
+  async deleteInvitation(invitation: AcceptInvitationDto): Promise<void> {
+    const { challengeId, guestId } = invitation;
+    this.redisService.del(`userInfo:${guestId}`);
+    await this.invitationRepository.delete({ challengeId, guestId: guestId });
   }
 }


### PR DESCRIPTION
## #️⃣ Part

- [ ] FE
- [x] BE


## 📝 작업 내용

1. SendInvitationDto 추가 
    -> challengId 
    -> mateEmail
2. create에서 초대 분리 
    -> 이미 초대된 사용자 에러처리 제거 ( 없어도 컬럼 추가 안됨) 
    -> 4명이상인 챌린지 들어가려고 할 시 예외처리




1. 호스트만 초대가능 추가하려다가 다른사람도 할 수 있지 않을까?
2. 초대장을 받았을 경우 수락했을 시 꽉찼을 경우 일단 초대장 삭제안함 
    -> 삭제해도 userCache가 남아있음 userInfo에는 여러 데이터가 담겨있어서 삭제하기 애매함
        -> 인원이 delete하는 경우 초대를 받아서 다시 들어갈 수 있기 때문
    -> 인원이 꽉 차고 이미 시작 되었다면
        -> 계속 남아있으면 안되지 않나??? 어차피 db 다시 조회후 삭제해야함



의문
1. 초대장을 받았을 경우 나머지 초대장 챌린지 종료 후 초대장 만료 안된거 보이는지? -> 안보임
        -> 초대장 삭제기능 -> 필요없어짐
	-> 초대 db 수정해야함 -> 필요없음

초대받은 사용자가 챌린지 수락시 모든 받은 초대장 expired 처리
    -> 수락하지 않은 초대장들도 수락한 초대장들과 똑같은 상태가됨


 

