### PR TITLE
fix: 이메일 인증 및 챌린지 추가 생성 문제 해결

### DIFF
--- a/backend/src/challenges/challenges.entity.ts
+++ b/backend/src/challenges/challenges.entity.ts
@@ -14,8 +14,8 @@ import {
 @Entity()
 @Index('UQ_host_active_challenge', ['hostId'], {
   unique: true,
-  where: 'completed = false',
-}) // complete된 챌린지는 hostId가 중복될 수 있으나, 아닌 경우는 중복이 불가하도록 unique 제약조건 추가
+  where: 'completed = false AND deleted = false',
+}) // complete된 챌린지 또는 deleted된 챌린지는 hostId가 중복될 수 있으나, 아닌 경우는 중복이 불가하도록 unique 제약조건 추가
 export class Challenges {
   @PrimaryGeneratedColumn()
   _id: number;

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -80,9 +80,9 @@ export class UserService {
       where: { email },
       withDeleted: true,
     });
-    if (!user) {
-      throw new NotFoundException('존재하지 않는 유저입니다.');
-    }
+    // if (!user) {
+    //   throw new NotFoundException('존재하지 않는 유저입니다.');
+    // }
     return user;
   }
 


### PR DESCRIPTION
## #️⃣ Part

- [ ] FE
- [x] BE


## 📝 작업 내용
1. complete된 챌린지 또는 deleted된 챌린지는 hostId가 중복될 수 있으나, 아닌 경우는 중복이 불가하도록 unique 제약조건 추가
2. 회원 존재 여부 확인 시 예외처리 삭제
