### PR TITLE
fix : challenge 업데이트시 db가 cache를 새로운 객체로 인식하여 새로운 컬럼을 만드는 문제 

### DIFF
--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -552,6 +552,8 @@ export class ChallengesService {
         userId,
         this.userService.decideMedalType(threshold),
       );
+    } else {
+      console.log('not enough qualifiedDaysCount...');
     }
     return true;
   }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -369,6 +369,7 @@ export class UserService {
     // 업데이트된 유저 정보를 저장합니다.
     // redis에 저장된 user 정보 삭제
     await this.redisService.del(`userInfo:${userId}`);
+    console.log('medal update', medalType);
     return await this.userRepository.save(user);
   }
 


### PR DESCRIPTION
## #️⃣ Part

- [ ] FE
- [x] BE

## 📝 작업 내용

1. 캐시 삭제로 일시 해결

[이슈]
1. complete시 complete된 컬럼을 하나 더 생성 원래 컬럼은 complete 되었지만 complete = false deleted = false 상태로 남아있어서 새로운 챌린지 생성 불가

2. 생성은 불가는 하지만 참여는 가능 챌린지 참여후 호스트가 포기할 시 참여한 사람을 a 호스트를 b라고 할시 a는 false, false 상태이므로 b가 a 한테 챌린지를 넘길 수 없어 오류 발생


두가지 해결